### PR TITLE
update: dashboardの検索ボタンの初期状態をdisabledから常にenabledに変更

### DIFF
--- a/app/(feature)/dashboard/index.test.tsx
+++ b/app/(feature)/dashboard/index.test.tsx
@@ -22,29 +22,22 @@ describe('Dashboard', () => {
         expect(input).toHaveAttribute('type', 'date');
       });
     });
-    test('Buttonがsubmit属性、disabledで1つレンダリングされる', () => {
+    test('Buttonがsubmit属性、Enabledで1つレンダリングされる', () => {
       render(<Dashboard />);
       const button = screen.getByRole('button');
       expect(button).toBeInTheDocument();
       expect(button).toHaveAttribute('type', 'submit');
-      expect(button).toBeDisabled();
-    });
-    test('検索項目を全て入力すると検索ボタンが有効になる', async () => {
-      render(<Dashboard />);
-      const select = screen.getByRole('combobox');
-      const startInput = screen.getByLabelText('開始');
-      const endInput = screen.getByLabelText('終了');
-      const button = screen.getByRole('button');
-      expect(button).toBeDisabled();
-      const user = userEvent.setup();
-
-      await user.click(select);
-      const option = await screen.findByText('Eito');
-      await user.click(option);
-
-      await user.type(startInput, '2022-01-01');
-      await user.type(endInput, '2022-01-02');
       expect(button).toBeEnabled();
+    });
+    test('検索項目を全て入力せず検索ボタンを押すとvalidationエラーになる', async () => {
+      render(<Dashboard />);
+      const assertionsText = ['対象を選択', '開始日を選択', '終了日を選択'];
+      const button = screen.getByRole('button');
+      const user = userEvent.setup();
+      await user.click(button);
+      assertionsText.forEach((text) => {
+        expect(screen.getByText(text)).toBeInTheDocument();
+      });
     });
   });
 });

--- a/app/(feature)/dashboard/page.tsx
+++ b/app/(feature)/dashboard/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useCallback, Suspense } from 'react';
+import React, { Suspense } from 'react';
 import { useForm, SubmitHandler, Controller } from 'react-hook-form';
 import { dashboardStyles } from './index.styles';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -26,23 +26,6 @@ type Props = {
     endDate: string;
   };
 };
-
-type IsDirtyFieldsProps = Partial<
-  Readonly<{
-    person?:
-      | {
-          value?: boolean | undefined;
-          label?: boolean | undefined;
-        }
-      | undefined;
-    selectDate?:
-      | {
-          startDate?: boolean | undefined;
-          endDate?: boolean | undefined;
-        }
-      | undefined;
-  }>
->;
 
 const options: OptionsType[] = [
   { value: 'all', label: 'All' },
@@ -72,20 +55,10 @@ export default function Page() {
   const {
     handleSubmit,
     control,
-    formState: { errors, dirtyFields },
+    formState: { errors },
   } = useForm<Props>({
     resolver: zodResolver(validationSchema),
   });
-
-  const isCheckingDirty = useCallback(
-    (dirtyFieldsObj: IsDirtyFieldsProps) => {
-      const { person, selectDate } = dirtyFieldsObj;
-      if (!person || !selectDate?.startDate || !selectDate?.endDate) return false;
-      return person && selectDate?.startDate && selectDate?.endDate;
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [dirtyFields !== undefined],
-  );
 
   const onSubmit: SubmitHandler<Props> = (data) => {
     const sendingData = {
@@ -139,12 +112,7 @@ export default function Page() {
           </div>
         </div>
         <div className={dashboardStyles.sendingButton}>
-          <Button
-            type="submit"
-            style="primary"
-            label="検索"
-            disabled={!isCheckingDirty(dirtyFields)}
-          />
+          <Button type="submit" style="primary" label="検索" />
         </div>
       </form>
       <div className="text-2xl">合計：¥{sumFetchData || 0}</div>


### PR DESCRIPTION
- 検索ボタンの状態を検知するロジックを削除
- 伴いテストも改修
- 実験的にセレクトボックスのテストを記述してみたかっただけで、実証できたので不要となった