### PR TITLE
chore: recoilを削除

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import { PropsWithChildren } from 'react';
 import './styles/globals.css';
 import { Header } from './components/Header';
 import type { NavType } from './components/Header';
-import RecoilProvider from './recoilProvider';
 
 export const metadata = {
   title: 'Record of Help',
@@ -18,10 +17,8 @@ export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="ja">
       <body>
-        <RecoilProvider>
-          <Header links={navItems} />
-          {children}
-        </RecoilProvider>
+        <Header links={navItems} />
+        {children}
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "react-error-boundary": "^4.0.12",
         "react-hook-form": "^7.48.2",
         "react-select": "^5.8.0",
-        "recoil": "^0.7.7",
         "swr": "^2.2.4",
         "typescript": "5.2.2",
         "zod": "^3.22.4"
@@ -12170,7 +12169,8 @@
     "node_modules/hamt_plus": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
-      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==",
+      "dev": true
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -16940,6 +16940,7 @@
       "version": "0.7.7",
       "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
       "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "dev": true,
       "dependencies": {
         "hamt_plus": "1.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "react-error-boundary": "^4.0.12",
     "react-hook-form": "^7.48.2",
     "react-select": "^5.8.0",
-    "recoil": "^0.7.7",
     "swr": "^2.2.4",
     "typescript": "5.2.2",
     "zod": "^3.22.4"


### PR DESCRIPTION
- 状態管理で利用予定であったがclientレンダリングでしか使えないので別のものを検討
- SSRでも使えそうな状態管理に変更する予定