### PR TITLE
upadte: useSignOutの実装、及びNavHeaderコンポーネントを追加

### DIFF
--- a/app/(feature)/navHeader/index.tsx
+++ b/app/(feature)/navHeader/index.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { Header, NavType } from '../../components/Header';
+import { useSignOut } from '../../hooks/useSignOut';
+import { useRouter } from 'next/navigation';
+
+const navItems: NavType = {
+  Form: './form',
+  Dashboard: './dashboard',
+};
+
+export const NavHeader = () => {
+  const { signOut } = useSignOut();
+  const router = useRouter();
+
+  const onSubmit = async () => {
+    await signOut();
+    router.replace('/login');
+  };
+  return <Header links={navItems} onClick={onSubmit} />;
+};

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -11,7 +11,7 @@ export type NavType = {
   Dashboard: string;
 };
 
-export const Header = ({ links }: { links: NavType }) => {
+export const Header = ({ links, onClick }: { links: NavType; onClick?: () => void }) => {
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
@@ -68,7 +68,7 @@ export const Header = ({ links }: { links: NavType }) => {
                 </li>
               ))}
               <li className={headerStyles.menuLiStyle}>
-                <Link href="#" className={headerStyles.menuLink}>
+                <Link href="#" className={headerStyles.menuLink} onClick={onClick}>
                   Logout
                 </Link>
               </li>

--- a/app/hooks/useSignOut.ts
+++ b/app/hooks/useSignOut.ts
@@ -1,6 +1,6 @@
 import { supabase } from '../libs/supabase';
 
-export const useSignOut = async () => {
+export const useSignOut = () => {
   const signOut = async () => {
     await supabase.auth.signOut();
   };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,23 +1,17 @@
 import { PropsWithChildren } from 'react';
 import './styles/globals.css';
-import { Header } from './components/Header';
-import type { NavType } from './components/Header';
+import { NavHeader } from './(feature)/navHeader';
 
 export const metadata = {
   title: 'Record of Help',
   description: 'This App is recording help by your children',
 };
 
-const navItems: NavType = {
-  Form: './form',
-  Dashboard: './dashboard',
-};
-
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="ja">
       <body>
-        <Header links={navItems} />
+        <NavHeader />
         {children}
       </body>
     </html>


### PR DESCRIPTION
- useSignOutのhookをHeaderコンポーネントに追加する上でNavHeaderコンポーネントを追加
- Headerメニューより、SignOutするとログイン画面へ戻る