### PR TITLE
fix: dashboardが検索できない、テーブルの問題を修正

### DIFF
--- a/app/(feature)/dashboard/index.test.tsx
+++ b/app/(feature)/dashboard/index.test.tsx
@@ -29,13 +29,19 @@ describe('Dashboard', () => {
       expect(button).toHaveAttribute('type', 'submit');
       expect(button).toBeEnabled();
     });
-    test('検索項目を全て入力せず検索ボタンを押すとvalidationエラーになる', async () => {
+    test('対象者を未選択、開始終了をクリアし検索ボタンを押すとvalidationエラーになる', async () => {
       render(<Dashboard />);
-      const assertionsText = ['対象を選択', '開始日を選択', '終了日を選択'];
+      const validationsText = ['対象を選択', '開始日を選択', '終了日を選択'];
       const button = screen.getByRole('button');
       const user = userEvent.setup();
+
+      const startInput = screen.getByLabelText('開始');
+      const endInput = screen.getByLabelText('終了');
+
+      await user.clear(startInput);
+      await user.clear(endInput);
       await user.click(button);
-      assertionsText.forEach((text) => {
+      validationsText.forEach((text) => {
         expect(screen.getByText(text)).toBeInTheDocument();
       });
     });

--- a/app/(feature)/dashboard/page.tsx
+++ b/app/(feature)/dashboard/page.tsx
@@ -43,9 +43,21 @@ const thData = {
 
 const wageItem = ['dish', 'curtain', 'prepareEat', 'landry', 'special'];
 
+const getNowMonthFirstLast = () => {
+  const nowDate = new Date();
+  const nowMonthFirst = new Date(nowDate.getFullYear(), nowDate.getMonth(), 1);
+  const nowMonthLast = new Date(nowDate.getFullYear(), nowDate.getMonth() + 1, 0);
+  return {
+    startDate: nowMonthFirst.toISOString().split('T')[0],
+    endDate: nowMonthLast.toISOString().split('T')[0],
+  };
+};
+
 export default function Page() {
   const { success, conditionsFetch } = useFetchRawsData();
   const fetchData: TdProps = success.rawsData;
+
+  const { startDate, endDate } = getNowMonthFirstLast();
 
   const sumFetchData = sumObjectArrayData(fetchData, wageItem);
 
@@ -54,6 +66,13 @@ export default function Page() {
     control,
     formState: { errors },
   } = useForm<Props>({
+    defaultValues: {
+      person: { value: '', label: '' },
+      selectDate: {
+        startDate,
+        endDate,
+      },
+    },
     resolver: zodResolver(validationSchema),
   });
 

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -6,7 +6,7 @@ export type PropsTableTd = Record<string, string | number | null>[];
 
 export const Table = forwardRef(
   ({ thData, tdData }: { thData: Record<string, string>; tdData: PropsTableTd | null }, _ref) => {
-    if (!tdData) {
+    if (!tdData || !tdData[0]) {
       return <div>データがありません</div>;
     }
     if (Object.keys(thData).length !== Object.keys(tdData[0]).length) {

--- a/app/hooks/useFetchRawsData.ts
+++ b/app/hooks/useFetchRawsData.ts
@@ -1,25 +1,15 @@
 'use client';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { supabase } from '../libs/supabase';
-import useSWR, { mutate } from 'swr';
+import { mutate } from 'swr';
 import type { Database } from '../../supabase/schema';
 
 type Props = Database['public']['Tables']['raws_data']['Row'][] | null;
 
-type ConditionsArgsType = {
+export type ConditionsArgsType = {
   startDate: string;
   endDate: string;
   person?: string;
-};
-
-const getNowMonthFirstLast = () => {
-  const nowDate = new Date();
-  const nowMonthFirst = new Date(nowDate.getFullYear(), nowDate.getMonth(), 1);
-  const nowMonthLast = new Date(nowDate.getFullYear(), nowDate.getMonth() + 1, 0);
-  return {
-    startDate: nowMonthFirst.toISOString().split('T')[0],
-    endDate: nowMonthLast.toISOString().split('T')[0],
-  };
 };
 
 const commonSupabaseFetcher = supabase
@@ -46,21 +36,10 @@ const conditionsFetcher = async (args: ConditionsArgsType) => {
 
 export const useFetchRawsData = () => {
   const [rawsData, setRawsData] = useState<Props | null>(null);
-  const { startDate, endDate } = getNowMonthFirstLast();
-  const sendingData: ConditionsArgsType = {
-    person: '',
-    startDate,
-    endDate,
-  };
-
-  const { data } = useSWR('raws_data', () => conditionsFetcher({ ...sendingData }));
-  useEffect(() => {
-    setRawsData(data?.data || null);
-  }, [data]);
 
   const mutateFetch = async (args: ConditionsArgsType) => {
     const result = await mutate('raws_data_conditions', conditionsFetcher({ ...args }));
-    setRawsData(result?.data || null);
+    setRawsData(() => result?.data || null);
   };
 
   return {


### PR DESCRIPTION
- dashboardに初回アクセス時のfetchと手動fetchのクエリが混ざり検索できなくなるので、初回fetchのロジックを削除
- 代替案としてdashboardの検索フィールド開始終了に初期値を設定
- データが存在しない場合、テーブルのエラーがあったため、0番目がnullの場合の条件を追加
- 伴うテスト修正