### PR TITLE
test: useSignOutと関連するUTを修正

### DIFF
--- a/app/(feature)/navHeader/index.tsx
+++ b/app/(feature)/navHeader/index.tsx
@@ -13,8 +13,8 @@ export const NavHeader = () => {
   const router = useRouter();
 
   const onSubmit = async () => {
-    await signOut();
-    router.replace('/login');
+    const out = await signOut();
+    if (!out || !out.error) router.replace('/login');
   };
   return <Header links={navItems} onClick={onSubmit} />;
 };

--- a/app/(feature)/navHeader/indext.test.tsx
+++ b/app/(feature)/navHeader/indext.test.tsx
@@ -5,6 +5,14 @@ import { NavHeader } from '.';
 import userEvent from '@testing-library/user-event';
 import mockRouter from 'next-router-mock';
 
+jest.mock('../../libs/supabase', () => ({
+  supabase: {
+    auth: {
+      signOut: jest.fn().mockResolvedValueOnce(() => Promise.resolve(undefined)),
+    },
+  },
+}));
+
 jest.mock('next/navigation', () => jest.requireActual('next-router-mock'));
 
 describe('NavHeader', () => {
@@ -16,6 +24,7 @@ describe('NavHeader', () => {
 
   afterEach(() => {
     mockReplaceRouter.mockRestore();
+    jest.clearAllMocks();
   });
 
   test('NavHeaderがレンダリングされる', () => {
@@ -27,6 +36,7 @@ describe('NavHeader', () => {
     const logout = screen.getByRole('link', { name: 'Logout' });
     const user = userEvent.setup();
     await user.click(logout);
+
     expect(mockReplaceRouter).toHaveBeenCalledWith('/login');
   });
 });

--- a/app/hooks/useSignOut.test.ts
+++ b/app/hooks/useSignOut.test.ts
@@ -1,14 +1,50 @@
 import { renderHook } from '@testing-library/react';
 import { useSignOut } from './useSignOut';
 
+jest.mock('../libs/supabase', () => ({
+  supabase: {
+    auth: {
+      signOut: jest.fn().mockResolvedValueOnce(undefined),
+    },
+  },
+}));
+
 describe('useSignOut', () => {
-  test('signOut関数を呼び出しコールできる', async () => {
-    expect.assertions(1);
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  test('signOut関数を呼び出すとundefinedがかえる', async () => {
     const { result } = renderHook(() => useSignOut());
-    const signOutSpy = jest.spyOn(result.current, 'signOut');
 
-    result.current.signOut();
-
-    expect(signOutSpy).toHaveBeenCalledTimes(1);
+    await expect(result.current.signOut()).resolves.toBe(undefined);
   });
 });
+
+// TODO: エラーの場合のmockとハッピーパスのmockをdescribeやtestなどでラップしても共存できない
+// jest.mock('../libs/supabase', () => ({
+//   supabase: {
+//     auth: {
+//       signOut: jest.fn().mockRejectedValueOnce({
+//         error: {
+//           name: 'AuthError',
+//           message: 'Your signOut is encounter the Error.',
+//           status: 400,
+//         },
+//       }),
+//     },
+//   },
+// }));
+
+// describe('useSignOut', () => {
+//   test('SignOutがエラーになる', async () => {
+//     const { result } = renderHook(() => useSignOut());
+
+//     await expect(result.current.signOut()).rejects.toMatchObject({
+//       error: {
+//         name: 'AuthError',
+//         message: 'Your signOut is encounter the Error.',
+//         status: 400,
+//       },
+//     });
+//   });
+// });

--- a/app/hooks/useSignOut.ts
+++ b/app/hooks/useSignOut.ts
@@ -2,7 +2,10 @@ import { supabase } from '../libs/supabase';
 
 export const useSignOut = () => {
   const signOut = async () => {
-    await supabase.auth.signOut();
+    const error = await supabase.auth.signOut();
+    if (error) {
+      return error;
+    }
   };
   return { signOut };
 };


### PR DESCRIPTION
- useSignOutの返り値でエラーの場合はエラーがかえるように改修
- 関連するnavHeaderの処理とそのテストを修正
- useSingOut自体のテスト修正
- エラーの場合のテストのmockが共存できないので後日対応する