### PR TITLE
update: useSignIn及びuseSignOutの改修

### DIFF
--- a/app/(feature)/login/page.tsx
+++ b/app/(feature)/login/page.tsx
@@ -27,10 +27,18 @@ export default function Page() {
 
   const login = useSignIn();
   const router = useRouter();
-  const onSubmit: SubmitHandler<Props> = async (data) => {
+  const onSubmit: SubmitHandler<Props> = async (inputData) => {
     setSubmitButton(true);
-    await login.signIn(data);
-    router.replace('/form');
+    const { data, error } = await login.signIn(inputData);
+    if (error) {
+      // eslint-disable-next-line no-alert
+      alert('ログインに失敗しました。');
+      setSubmitButton(false);
+      return;
+    }
+    if (data) {
+      router.replace('/form');
+    }
   };
 
   return (

--- a/app/(feature)/navHeader/index.tsx
+++ b/app/(feature)/navHeader/index.tsx
@@ -15,6 +15,7 @@ export const NavHeader = () => {
   const onSubmit = async () => {
     const out = await signOut();
     if (out?.error) {
+      // eslint-disable-next-line no-alert
       alert('ログアウトに失敗しました。');
     } else {
       router.replace('/login');

--- a/app/(feature)/navHeader/indext.test.tsx
+++ b/app/(feature)/navHeader/indext.test.tsx
@@ -45,7 +45,7 @@ describe('NavHeader', () => {
       } as unknown as AuthError,
     };
 
-    jest.spyOn(Supabase.supabase.auth, 'signOut').mockRejectedValueOnce(error);
+    jest.spyOn(Supabase.supabase.auth, 'signOut').mockRejectedValueOnce({ ...error });
 
     render(<NavHeader />);
     const logout = screen.getByRole('link', { name: 'Logout' });

--- a/app/hooks/useSignIn.test.ts
+++ b/app/hooks/useSignIn.test.ts
@@ -1,10 +1,18 @@
 import { renderHook } from '@testing-library/react';
 import { useSignIn, Props } from './useSignIn';
+import * as Supabase from '../libs/supabase';
+import { AuthTokenResponse, AuthError } from '@supabase/supabase-js';
+
+jest.mock('../libs/supabase');
 
 const mockArgs: Props = {
   email: 'test@gmail.com',
   password: 'password',
 };
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('useSignIn', () => {
   test('emailとpasswordをセットできる', async () => {
@@ -16,6 +24,48 @@ describe('useSignIn', () => {
 
     expect(signInSpy).toHaveBeenCalledWith({
       ...mockArgs,
+    });
+  });
+
+  test('signOut関数が成功すると、userとsessionが返る', async () => {
+    const data = {
+      data: {
+        user: {
+          id: '1',
+          email: 'test@gmail.com',
+        },
+        session: {
+          access: 'access',
+          refresh: 'refresh',
+          expires_at: 'expires_at',
+        },
+      },
+    };
+    jest.spyOn(Supabase.supabase.auth, 'signInWithPassword').mockResolvedValueOnce({
+      ...data,
+    } as unknown as AuthTokenResponse);
+    const { result } = renderHook(() => useSignIn());
+
+    await expect(result.current.signIn(mockArgs)).resolves.toMatchObject({
+      ...data,
+    });
+  });
+  test('signOut関数失敗するとerrorが返る', async () => {
+    const error = {
+      error: {
+        name: 'AuthError',
+        message: 'Your signOut is encounter the Error.',
+        status: 400,
+        __isAuthError: true,
+      },
+    };
+    jest.spyOn(Supabase.supabase.auth, 'signInWithPassword').mockRejectedValueOnce({
+      ...error,
+    } as unknown as AuthError);
+    const { result } = renderHook(() => useSignIn());
+
+    await expect(result.current.signIn(mockArgs)).rejects.toMatchObject({
+      ...error,
     });
   });
 });

--- a/app/hooks/useSignIn.ts
+++ b/app/hooks/useSignIn.ts
@@ -7,9 +7,9 @@ export type Props = {
 
 export const useSignIn = () => {
   const signIn = async (args: Props) => {
-    const { error } = await supabase.auth.signInWithPassword({ ...args });
-    // eslint-disable-next-line no-alert
-    alert(error?.message);
+    const { data, error } = (await supabase.auth.signInWithPassword({ ...args })) || {};
+
+    return { data, error };
   };
   return { signIn };
 };

--- a/app/hooks/useSignOut.test.ts
+++ b/app/hooks/useSignOut.test.ts
@@ -25,9 +25,9 @@ describe('useSignOut', () => {
         __isAuthError: true,
       } as unknown as AuthError,
     };
-    jest.spyOn(Supabase.supabase.auth, 'signOut').mockRejectedValueOnce(error);
+    jest.spyOn(Supabase.supabase.auth, 'signOut').mockRejectedValueOnce({ ...error });
     const { result } = renderHook(() => useSignOut());
 
-    await expect(result.current.signOut()).rejects.toMatchObject(error);
+    await expect(result.current.signOut()).rejects.toMatchObject({ ...error });
   });
 });


### PR DESCRIPTION
- useSignInの成功の場合のUTを追加
- useSignInが成功の場合、dataを返すように改修
- useSignInの改修に伴うloginページの改修
- useSignOutのテストの軽微な修正
- navHeaderの軽微な修正