### PR TITLE
update: zustandでログイン状態が管理できるように改修

### DIFF
--- a/.vscode/setting.json
+++ b/.vscode/setting.json
@@ -1,6 +1,7 @@
 {
   "editor.defaultFormatter": null,
   "editor.formatOnSave": true,
+  "jest.autoRun": "off",
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   }

--- a/app/(feature)/login/layout.tsx
+++ b/app/(feature)/login/layout.tsx
@@ -1,10 +1,23 @@
 import { PropsWithChildren } from 'react';
+import { headers, cookies } from 'next/headers';
+import { createServerComponentSupabaseClient } from '@supabase/auth-helpers-nextjs';
+import type { Database } from '@/supabase/schema';
+import SupabaseListener from './supabaseListener';
 
 export const metadata = {
   title: 'Record of Help | Login',
   description: 'This App is recording help by your children',
 };
 
-export default function LoginLayout({ children }: PropsWithChildren) {
-  return <>{children}</>;
+export default async function LoginLayout({ children }: PropsWithChildren) {
+  const supabase = createServerComponentSupabaseClient<Database>({ headers, cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  return (
+    <>
+      <SupabaseListener accessToken={session?.access_token} />
+      {children}
+    </>
+  );
 }

--- a/app/(feature)/login/page.tsx
+++ b/app/(feature)/login/page.tsx
@@ -29,16 +29,15 @@ export default function Page() {
   const router = useRouter();
   const onSubmit: SubmitHandler<Props> = async (inputData) => {
     setSubmitButton(true);
-    const { data, error } = await login.signIn(inputData);
+    const { error } = await login.signIn(inputData);
     if (error) {
       // eslint-disable-next-line no-alert
       alert('ログインに失敗しました。');
       setSubmitButton(false);
       return;
     }
-    if (data) {
-      router.replace('/form');
-    }
+
+    router.replace('/form');
   };
 
   return (

--- a/app/(feature)/login/supabaseListener.tsx
+++ b/app/(feature)/login/supabaseListener.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/app/libs/supabase';
+import { useStore } from '@/app/store';
+
+const SupabaseListener: React.FC<{ accessToken?: string }> = ({ accessToken }) => {
+  const router = useRouter();
+  const { updateLoginUser } = useStore();
+
+  useEffect(() => {
+    const getUserInfo = async () => {
+      const { data } = await supabase.auth.getSession();
+      if (data.session) {
+        updateLoginUser({
+          id: data.session?.user.id,
+          email: data.session?.user.email!,
+        });
+      }
+    };
+    getUserInfo();
+    supabase.auth.onAuthStateChange((_, session) => {
+      updateLoginUser({ id: session?.user.id!, email: session?.user.email! });
+      if (session?.access_token !== accessToken) router.refresh();
+    });
+  }, [accessToken, router, updateLoginUser]);
+
+  return null;
+};
+
+export default SupabaseListener;

--- a/app/hooks/useSignIn.test.ts
+++ b/app/hooks/useSignIn.test.ts
@@ -27,28 +27,13 @@ describe('useSignIn', () => {
     });
   });
 
-  test('signOut関数が成功すると、userとsessionが返る', async () => {
-    const data = {
-      data: {
-        user: {
-          id: '1',
-          email: 'test@gmail.com',
-        },
-        session: {
-          access: 'access',
-          refresh: 'refresh',
-          expires_at: 'expires_at',
-        },
-      },
-    };
-    jest.spyOn(Supabase.supabase.auth, 'signInWithPassword').mockResolvedValueOnce({
-      ...data,
-    } as unknown as AuthTokenResponse);
+  test('signOut関数が成功すると、errorにはundefinedが返る', async () => {
+    jest
+      .spyOn(Supabase.supabase.auth, 'signInWithPassword')
+      .mockResolvedValueOnce({ error: undefined } as unknown as AuthTokenResponse);
     const { result } = renderHook(() => useSignIn());
 
-    await expect(result.current.signIn(mockArgs)).resolves.toMatchObject({
-      ...data,
-    });
+    await expect(result.current.signIn(mockArgs)).resolves.toStrictEqual({ error: undefined });
   });
   test('signOut関数失敗するとerrorが返る', async () => {
     const error = {

--- a/app/hooks/useSignIn.ts
+++ b/app/hooks/useSignIn.ts
@@ -7,9 +7,9 @@ export type Props = {
 
 export const useSignIn = () => {
   const signIn = async (args: Props) => {
-    const { data, error } = (await supabase.auth.signInWithPassword({ ...args })) || {};
+    const { error } = (await supabase.auth.signInWithPassword({ ...args })) || {};
 
-    return { data, error };
+    return { error };
   };
   return { signIn };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.3.2",
-        "@supabase/auth-helpers-nextjs": "^0.9.0",
+        "@supabase/auth-helpers-nextjs": "^0.5.2",
         "@supabase/supabase-js": "^2.39.1",
         "@types/node": "20.8.10",
         "@types/react": "18.2.34",
@@ -6173,26 +6173,22 @@
       }
     },
     "node_modules/@supabase/auth-helpers-nextjs": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.9.0.tgz",
-      "integrity": "sha512-V+UKFngSCkzAucX3Zi5D4TRiJZUUx0RDme7W217nIkwhCTvJY7Ih2L1cgnAMihQost2YYgTzJ7DrUzz4mm8i8A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.5.2.tgz",
+      "integrity": "sha512-B+sQFVEImAYOJKyyNX1DWqTF2qVf9SocOM1GD4eGHon6ulvLOo2a8V+v1jZAuLOBF6yzVIYnZucuYKZCiNP/Eg==",
       "dependencies": {
-        "@supabase/auth-helpers-shared": "0.6.3",
-        "set-cookie-parser": "^2.6.0"
+        "@supabase/auth-helpers-shared": "0.2.3"
       },
       "peerDependencies": {
-        "@supabase/supabase-js": "^2.19.0"
+        "@supabase/supabase-js": "^2.0.4"
       }
     },
     "node_modules/@supabase/auth-helpers-shared": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.6.3.tgz",
-      "integrity": "sha512-xYQRLFeFkL4ZfwC7p9VKcarshj3FB2QJMgJPydvOY7J5czJe6xSG5/wM1z63RmAzGbCkKg+dzpq61oeSyWiGBQ==",
-      "dependencies": {
-        "jose": "^4.14.4"
-      },
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.2.3.tgz",
+      "integrity": "sha512-Xwnd2UQ/VTjTKIuVg1Xl/ryrElbSccOJhC11jbVPHOs7Y6yxzy9APxQs//jj4IpbDH4uOEDCdpMIJ0tzRxj9DQ==",
       "peerDependencies": {
-        "@supabase/supabase-js": "^2.19.0"
+        "@supabase/supabase-js": "^2.0.4"
       }
     },
     "node_modules/@supabase/functions-js": {
@@ -14186,14 +14182,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/jose": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
-      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -17555,11 +17543,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
-      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
     },
     "node_modules/set-function-length": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.2",
-    "@supabase/auth-helpers-nextjs": "^0.9.0",
+    "@supabase/auth-helpers-nextjs": "^0.5.2",
     "@supabase/supabase-js": "^2.39.1",
     "@types/node": "20.8.10",
     "@types/react": "18.2.34",


### PR DESCRIPTION
- zustandを使い`useStore`と`login`のlayoutでログイン状態をグローバルで管理できるように改修
- `createServerComponentSupabaseClient`が利用できなかったためヘルパーをダウングレード
- 上記に伴い、`useSignIn`から分割代入していた`data`を削除