### PR TITLE
udpate: ログイン時はメールアドレスがHeaderに表示されるよう改修

### DIFF
--- a/app/(feature)/navHeader/index.tsx
+++ b/app/(feature)/navHeader/index.tsx
@@ -2,6 +2,7 @@
 import { Header, NavType } from '@/app/components/Header';
 import { useSignOut } from '@/app/hooks/useSignOut';
 import { useRouter } from 'next/navigation';
+import { useStore } from '@/app/store';
 
 const navItems: NavType = {
   Form: './form',
@@ -11,6 +12,7 @@ const navItems: NavType = {
 export const NavHeader = () => {
   const { signOut } = useSignOut();
   const router = useRouter();
+  const loginUser = useStore((state) => state.loginUser.email);
 
   const onSubmit = async () => {
     const out = await signOut();
@@ -21,5 +23,5 @@ export const NavHeader = () => {
       router.replace('/login');
     }
   };
-  return <Header links={navItems} onClick={onSubmit} />;
+  return <Header links={navItems} onClick={onSubmit} loginUser={loginUser} />;
 };

--- a/app/components/Header/index.test.tsx
+++ b/app/components/Header/index.test.tsx
@@ -28,8 +28,9 @@ describe('Header', () => {
 
   test('Logoutをクリックすると、propsで渡したonClick関数が1回実行される', async () => {
     const mockOnClick = jest.fn();
-    render(<Header links={mockNavItems} onClick={mockOnClick} />);
-    const logout = screen.getByText('Logout');
+    const mockLoginUser = 'test@test.com';
+    render(<Header links={mockNavItems} onClick={mockOnClick} loginUser={mockLoginUser} />);
+    const logout = screen.getByText(mockLoginUser);
     const user = userEvent.setup();
     await user.click(logout);
     expect(mockOnClick).toHaveBeenCalledTimes(1);

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -11,7 +11,15 @@ export type NavType = {
   Dashboard: string;
 };
 
-export const Header = ({ links, onClick }: { links: NavType; onClick: () => void }) => {
+export const Header = ({
+  links,
+  loginUser,
+  onClick,
+}: {
+  links: NavType;
+  onClick: () => void;
+  loginUser?: string | null;
+}) => {
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
@@ -69,7 +77,7 @@ export const Header = ({ links, onClick }: { links: NavType; onClick: () => void
               ))}
               <li className={headerStyles.menuLiStyle}>
                 <Link href="#" className={headerStyles.menuLink} onClick={onClick}>
-                  Logout
+                  {loginUser || 'Login'}
                 </Link>
               </li>
             </ul>


### PR DESCRIPTION
- Zustandでログインの状態を持ち、ログインしている場合はメールアドレスが表示されるよう改修
- 上記関連するUTを修正
- サインアウト時のテストをskipしていた箇所も修正しSkipを除去