### PR TITLE
update:  supabaseAuthをsupabaseへリネーム

### DIFF
--- a/app/(feature)/form/PricesList/index.tsx
+++ b/app/(feature)/form/PricesList/index.tsx
@@ -1,44 +1,34 @@
 'use client';
-import React, { forwardRef } from 'react';
+import React from 'react';
 import { Checkbox } from '@/app/components/Checkbox';
 import { useFetchPricesList } from '@/app/hooks/useFetchPricesList';
 import { UseFormRegisterReturn } from 'react-hook-form';
 
-export const PricesList = forwardRef(
-  (
-    {
-      register,
-    }: {
-      register: UseFormRegisterReturn<'items.helps'>;
-    },
-    _ref,
-  ) => {
-    const pricesListRaw = useFetchPricesList();
+export const PricesList = ({ register }: { register: UseFormRegisterReturn<'items.helps'> }) => {
+  const pricesListRaw = useFetchPricesList();
 
-    if (pricesListRaw?.isLoading) return <>Loading中やで</>;
+  if (pricesListRaw?.isLoading) return <>Loading中やで</>;
 
-    if (pricesListRaw?.error) throw new Error(pricesListRaw.error.message);
+  if (pricesListRaw?.error) throw new Error(pricesListRaw.error.message);
 
-    const pricesList = pricesListRaw?.data?.map((item) => ({
-      id: item.id,
-      label: item.label,
-      column: item.help,
-      value: item.prices_list[0].price,
-    }));
+  const pricesList = pricesListRaw?.data?.map((item) => ({
+    id: item.id,
+    label: item.label,
+    column: item.help,
+    value: item.prices_list[0].price,
+  }));
 
-    return (
-      <>
-        {pricesList?.map((item) => (
-          <Checkbox
-            key={item.id}
-            label={item.label}
-            id={item.id}
-            {...register}
-            {..._ref}
-            value={`${item.column},${item.value}`}
-          />
-        ))}
-      </>
-    );
-  },
-);
+  return (
+    <>
+      {pricesList?.map((item) => (
+        <Checkbox
+          key={item.id}
+          label={item.label}
+          id={item.id}
+          {...register}
+          value={`${item.column},${item.value}`}
+        />
+      ))}
+    </>
+  );
+};

--- a/app/(feature)/form/page.tsx
+++ b/app/(feature)/form/page.tsx
@@ -22,18 +22,6 @@ export default function Page() {
 
   const post = usePostHelp();
   const router = useRouter();
-  // const token = useCheckLocalStorageToken();
-
-  // useEffect(() => {
-  //   if (!token) router.replace('/login');
-  // }, [])
-
-  // const pricesList = pricesListRaw?.data?.map((item) => ({
-  //   id: item.id,
-  //   label: item.label,
-  //   column: item.help,
-  //   value: item.prices_list[0].price,
-  // }));
 
   const onSubmit: SubmitHandler<Props> = async (data) => {
     const helpsData = convertHelps(data.items.helps);

--- a/app/(feature)/navHeader/indext.test.tsx
+++ b/app/(feature)/navHeader/indext.test.tsx
@@ -4,11 +4,11 @@ import '@testing-library/jest-dom';
 import { NavHeader } from '.';
 import userEvent from '@testing-library/user-event';
 import mockRouter from 'next-router-mock';
-import * as SupabaseAuth from '@/app/libs/supabaseAuth';
+import * as Supabase from '@/app/libs/supabase';
 import { AuthError } from '@supabase/supabase-js';
 import * as Zustand from '@/app/store';
 
-jest.mock('../../libs/supabaseAuth');
+jest.mock('../../libs/supabase');
 jest.mock('next/navigation', () => jest.requireActual('next-router-mock'));
 jest.mock('../../store');
 
@@ -56,9 +56,7 @@ describe('NavHeader', () => {
         message: 'error',
       } as AuthError,
     };
-    jest
-      .spyOn(SupabaseAuth.supabaseAuth.auth, 'signOut')
-      .mockImplementation(() => Promise.resolve(error));
+    jest.spyOn(Supabase.supabase.auth, 'signOut').mockImplementation(() => Promise.resolve(error));
     render(<NavHeader />);
     const logout = screen.getByRole('link', { name: mockedLoginUser });
     const user = userEvent.setup();

--- a/app/hooks/useFetchPricesList.ts
+++ b/app/hooks/useFetchPricesList.ts
@@ -1,10 +1,10 @@
-import { supabaseAuth } from '@/app/libs/supabaseAuth';
+import { supabase } from '@/app/libs/supabase';
 import useSWR from 'swr';
 import type { PricesHelpsList } from '@/app/types';
 
 const fetcher = async () => {
   try {
-    const fetchSupabase = () => supabaseAuth.from('helps_list').select('*, prices_list (*)');
+    const fetchSupabase = () => supabase.from('helps_list').select('*, prices_list (*)');
     const { data, error } = await fetchSupabase();
     return { data, error };
   } catch (error) {

--- a/app/hooks/useFetchRawsData.ts
+++ b/app/hooks/useFetchRawsData.ts
@@ -1,6 +1,6 @@
 'use client';
 import { useState, useEffect } from 'react';
-import { supabaseAuth } from '@/app/libs/supabaseAuth';
+import { supabase } from '@/app/libs/supabase';
 import useSWR, { mutate } from 'swr';
 import type { Database } from '@/supabase/schema';
 
@@ -23,7 +23,7 @@ const getNowMonthFirstLast = () => {
 };
 
 const conditionsFetcher = async (args: ConditionsArgsType) => {
-  const commonSupabaseFetcher = supabaseAuth
+  const commonSupabaseFetcher = supabase
     .from('raws_data')
     .select('*')
     .order('created_at', { ascending: true });

--- a/app/hooks/usePostHelp.ts
+++ b/app/hooks/usePostHelp.ts
@@ -1,4 +1,4 @@
-import { supabaseAuth } from '@/app/libs/supabaseAuth';
+import { supabase } from '@/app/libs/supabase';
 
 export type Props = {
   person: string;
@@ -12,7 +12,7 @@ export type Props = {
 
 export const usePostHelp = () => {
   const postHelp = async (args: Props) => {
-    const { data, error } = await supabaseAuth.from('raws_data').insert([args]);
+    const { data, error } = await supabase.from('raws_data').insert([args]);
     return { data, error };
   };
   return { postHelp };

--- a/app/hooks/useSignIn.test.ts
+++ b/app/hooks/useSignIn.test.ts
@@ -1,9 +1,9 @@
 import { renderHook } from '@testing-library/react';
 import { useSignIn, Props } from './useSignIn';
-import * as SupabaseAuth from '@/app/libs/supabaseAuth';
+import * as Supabase from '@/app/libs/supabase';
 import { AuthTokenResponse, AuthError } from '@supabase/supabase-js';
 
-jest.mock('../libs/supabaseAuth');
+jest.mock('../libs/supabase');
 
 const mockArgs: Props = {
   email: 'test@gmail.com',
@@ -28,7 +28,7 @@ describe('useSignIn', () => {
 
   test('signOut関数が成功すると、errorにはundefinedが返る', async () => {
     jest
-      .spyOn(SupabaseAuth.supabaseAuth.auth, 'signInWithPassword')
+      .spyOn(Supabase.supabase.auth, 'signInWithPassword')
       .mockResolvedValueOnce({ error: null } as unknown as AuthTokenResponse);
     const { result } = renderHook(() => useSignIn());
 
@@ -43,7 +43,7 @@ describe('useSignIn', () => {
         __isAuthError: true,
       },
     };
-    jest.spyOn(SupabaseAuth.supabaseAuth.auth, 'signInWithPassword').mockRejectedValueOnce({
+    jest.spyOn(Supabase.supabase.auth, 'signInWithPassword').mockRejectedValueOnce({
       ...error,
     } as unknown as AuthError);
     const { result } = renderHook(() => useSignIn());

--- a/app/hooks/useSignIn.ts
+++ b/app/hooks/useSignIn.ts
@@ -1,4 +1,4 @@
-import { supabaseAuth } from '@/app/libs/supabaseAuth';
+import { supabase } from '@/app/libs/supabase';
 
 export type Props = {
   email: string;
@@ -7,7 +7,7 @@ export type Props = {
 
 export const useSignIn = () => {
   const signIn = async (args: Props) => {
-    const result = await supabaseAuth.auth.signInWithPassword({ ...args });
+    const result = await supabase.auth.signInWithPassword({ ...args });
 
     const error = result?.error || null;
 

--- a/app/hooks/useSignOut.test.ts
+++ b/app/hooks/useSignOut.test.ts
@@ -1,16 +1,16 @@
 import { renderHook } from '@testing-library/react';
 import { useSignOut } from './useSignOut';
-import * as SupabaseAuth from '@/app/libs/supabaseAuth';
+import * as Supabase from '@/app/libs/supabase';
 import { AuthError } from '@supabase/supabase-js';
 
-jest.mock('../libs/supabaseAuth');
+jest.mock('../libs/supabase');
 
 describe('useSignOut', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
   test('signOut関数が成功すると、nullが返る', async () => {
-    jest.spyOn(SupabaseAuth.supabaseAuth.auth, 'signOut').mockResolvedValueOnce({ error: null });
+    jest.spyOn(Supabase.supabase.auth, 'signOut').mockResolvedValueOnce({ error: null });
     const { result } = renderHook(() => useSignOut());
 
     await expect(result.current.signOut()).resolves.toMatchObject({ error: null });
@@ -25,7 +25,7 @@ describe('useSignOut', () => {
         __isAuthError: true,
       } as unknown as AuthError,
     };
-    jest.spyOn(SupabaseAuth.supabaseAuth.auth, 'signOut').mockRejectedValueOnce({ ...error });
+    jest.spyOn(Supabase.supabase.auth, 'signOut').mockRejectedValueOnce({ ...error });
     const { result } = renderHook(() => useSignOut());
 
     await expect(result.current.signOut()).rejects.toMatchObject({ ...error });

--- a/app/hooks/useSignOut.ts
+++ b/app/hooks/useSignOut.ts
@@ -1,8 +1,8 @@
-import { supabaseAuth } from '@/app/libs/supabaseAuth';
+import { supabase } from '@/app/libs/supabase';
 
 export const useSignOut = () => {
   const signOut = async () => {
-    const error = await supabaseAuth.auth.signOut();
+    const error = await supabase.auth.signOut();
     if (error) {
       return error;
     }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from 'react';
 import './styles/globals.css';
 import { NavHeader } from '@/app/(feature)/navHeader';
 import SupabaseListener from '@/app/libs/supabaseListener';
-import { supabaseAuth } from './libs/supabaseAuth';
+import { supabase } from './libs/supabase';
 
 export const metadata = {
   title: 'Record of Help',
@@ -12,7 +12,7 @@ export const metadata = {
 export default async function RootLayout({ children }: PropsWithChildren) {
   const {
     data: { session },
-  } = await supabaseAuth.auth.getSession();
+  } = await supabase.auth.getSession();
 
   return (
     <html lang="ja">

--- a/app/libs/supabase.ts
+++ b/app/libs/supabase.ts
@@ -1,7 +1,6 @@
-import { createClient } from '@supabase/supabase-js';
-import { Database } from '@/supabase/schema';
+import { createBrowserClient } from '@supabase/ssr';
 
-export const supabase = createClient<Database>(
+export const supabase = createBrowserClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
 );

--- a/app/libs/supabaseAuth.ts
+++ b/app/libs/supabaseAuth.ts
@@ -1,6 +1,0 @@
-import { createBrowserClient } from '@supabase/ssr';
-
-export const supabaseAuth = createBrowserClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-);

--- a/app/libs/supabaseLegacy.ts
+++ b/app/libs/supabaseLegacy.ts
@@ -1,0 +1,7 @@
+import { createClient } from '@supabase/supabase-js';
+import { Database } from '@/supabase/schema';
+
+export const supabase = createClient<Database>(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+);

--- a/app/libs/supabaseListener.tsx
+++ b/app/libs/supabaseListener.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { supabaseAuth } from '@/app/libs/supabaseAuth';
+import { supabase } from '@/app/libs/supabase';
 import { useStore } from '@/app/store';
 
 const SupabaseListener: React.FC<{ accessToken?: string }> = ({ accessToken }) => {
@@ -10,7 +10,8 @@ const SupabaseListener: React.FC<{ accessToken?: string }> = ({ accessToken }) =
 
   useEffect(() => {
     const getUserInfo = async () => {
-      const { data } = await supabaseAuth.auth.getSession();
+      const { data } = await supabase.auth.getSession();
+      console.log('listenerのdata', data);
       if (data.session) {
         updateLoginUser({
           id: data.session?.user.id,
@@ -19,7 +20,7 @@ const SupabaseListener: React.FC<{ accessToken?: string }> = ({ accessToken }) =
       }
     };
     getUserInfo();
-    supabaseAuth.auth.onAuthStateChange((_, session) => {
+    supabase.auth.onAuthStateChange((_, session) => {
       updateLoginUser({ id: session?.user.id!, email: session?.user.email! });
       if (session?.access_token !== accessToken) router.refresh();
     });


### PR DESCRIPTION
    - 既存の`supabase`は`supabaseLegacy`へリネーム
    - `supabaseAuth`をリネームすることによりカスタムhook、及び関連ファイルも修正
    - 直接関連しないが、不要なコメントアウトを削除
    - PricesListの`forwardRef`のラップも不要そうなので一旦削除