### PR TITLE
feat:Adminでない場合、formのリンクをレンダリングしない

### DIFF
--- a/app/(feature)/navHeader/index.tsx
+++ b/app/(feature)/navHeader/index.tsx
@@ -1,11 +1,16 @@
 'use client';
-import { Header, NavType } from '@/app/components/Header';
+import { Header } from '@/app/components/Header';
 import { useSignOut } from '@/app/hooks/useSignOut';
 import { useRouter } from 'next/navigation';
 import { useStore } from '@/app/store';
+import { useFetchMember } from '@/app/hooks/useFetchMember';
 
-const navItems: NavType = {
+const navItemsWithAdmin = {
   Form: './form',
+  Dashboard: './dashboard',
+};
+
+const navItemsWithMember = {
   Dashboard: './dashboard',
 };
 
@@ -13,6 +18,8 @@ export const NavHeader = () => {
   const { signOut } = useSignOut();
   const router = useRouter();
   const loginUser = useStore((state) => state.loginUser.email);
+  const { data } = useFetchMember({ email: loginUser });
+  const auth = data.data?.[0]?.admin;
 
   const onSubmit = async () => {
     const out = await signOut();
@@ -23,5 +30,11 @@ export const NavHeader = () => {
       router.replace('/login');
     }
   };
-  return <Header links={navItems} onClick={onSubmit} loginUser={loginUser} />;
+  return (
+    <Header
+      links={auth ? navItemsWithAdmin : navItemsWithMember}
+      onClick={onSubmit}
+      loginUser={loginUser}
+    />
+  );
 };

--- a/app/components/Header/index.stories.tsx
+++ b/app/components/Header/index.stories.tsx
@@ -1,16 +1,24 @@
 import React from 'react';
-import { Header, NavType } from '.';
+import { Header, NavAdminType, NavMemberType } from '.';
 
 export default {
   title: 'app/components/Header',
   component: Header,
 };
 
-const mockNavItems: NavType = {
+const mockNavAdminItems: NavAdminType = {
   Form: './form',
   Dashboard: './dashboard',
 };
 
-export const Default: React.FC = (): JSX.Element => {
-  return <Header links={mockNavItems} onClick={() => {}} />;
+const mockNavMemberItems: NavMemberType = {
+  Dashboard: './dashboard',
+};
+
+export const Admin: React.FC = (): JSX.Element => {
+  return <Header links={mockNavAdminItems} onClick={() => {}} />;
+};
+
+export const Member: React.FC = (): JSX.Element => {
+  return <Header links={mockNavMemberItems} onClick={() => {}} />;
 };

--- a/app/components/Header/index.test.tsx
+++ b/app/components/Header/index.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { Header, headerText, NavType } from '.';
+import { Header, headerText, NavAdminType } from '.';
 import userEvent from '@testing-library/user-event';
 
-const mockNavItems: NavType = {
+const mockNavItems: NavAdminType = {
   Form: './form',
   Dashboard: './dashboard',
 };

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -6,8 +6,12 @@ import { headerStyles } from './index.styles';
 
 export const headerText = 'Record of help';
 
-export type NavType = {
+export type NavAdminType = {
   Form: string;
+  Dashboard: string;
+};
+
+export type NavMemberType = {
   Dashboard: string;
 };
 
@@ -16,7 +20,7 @@ export const Header = ({
   loginUser,
   onClick,
 }: {
-  links: NavType;
+  links: NavAdminType | NavMemberType;
   onClick: () => void;
   loginUser?: string | null;
 }) => {

--- a/app/hooks/useFetchMember.ts
+++ b/app/hooks/useFetchMember.ts
@@ -1,0 +1,25 @@
+import { supabase } from '@/app/libs/supabase';
+import useSWR from 'swr';
+
+const fetcher = async ({ email }: { email: string | null }) => {
+  try {
+    const fetchSupabase = () => supabase.from('members_list').select('admin').eq('email', email);
+    const { data, error } = await fetchSupabase();
+    return { data, error };
+  } catch (error) {
+    throw new Error(String(error));
+  }
+};
+
+export const useFetchMember = ({ email }: { email: string | null }) => {
+  const { data, error, isLoading } = useSWR('member_list', () => fetcher({ email }), {
+    suspense: true,
+    fallbackData: { data: null, error: null },
+  });
+
+  return {
+    data,
+    error,
+    isLoading,
+  };
+};

--- a/app/libs/supabaseListener.tsx
+++ b/app/libs/supabaseListener.tsx
@@ -11,7 +11,7 @@ const SupabaseListener: React.FC<{ accessToken?: string }> = ({ accessToken }) =
   useEffect(() => {
     const getUserInfo = async () => {
       const { data } = await supabase.auth.getSession();
-      console.log('listenerのdata', data);
+
       if (data.session) {
         updateLoginUser({
           id: data.session?.user.id,


### PR DESCRIPTION
- supbaseの`member_list`をfetchし、登録メンバーのadmin状況を取得するカスタムhooksを作成
- navHeaderでカスタムhooksからadmin状況を取得し、adminが`false`の場合はFormのリンクをレンダリングしない
- 直接URLにアクセスすると表示はされる穴はある（pricesListは表示されないのでPOST自体はできない）