### PR TITLE
refactoring: ログインしているAdminの状態のくだりをリファクタリング

### DIFF
--- a/app/(feature)/login/page.tsx
+++ b/app/(feature)/login/page.tsx
@@ -7,6 +7,7 @@ import { validationSchema } from './validationSchema';
 import { Button } from '@/app/components/Button';
 import { Input } from '@/app/components/Input';
 import { useSignIn } from '@/app/hooks/useSignIn';
+import { useStore } from '@/app/store';
 
 export type Props = {
   email: string;
@@ -27,6 +28,7 @@ export default function Page() {
 
   const login = useSignIn();
   const router = useRouter();
+  const loginAuth = useStore((state) => state.loginUser.auth);
   const onSubmit: SubmitHandler<Props> = async (inputData) => {
     setSubmitButton(true);
     const { error } = await login.signIn(inputData);
@@ -35,7 +37,7 @@ export default function Page() {
       alert(`ログインに失敗しました。\n ${error.message}`);
       setSubmitButton(false);
     } else {
-      router.replace('/form');
+      router.replace(loginAuth ? '/form' : '/dashboard');
     }
   };
 

--- a/app/(feature)/navHeader/index.tsx
+++ b/app/(feature)/navHeader/index.tsx
@@ -3,7 +3,6 @@ import { Header } from '@/app/components/Header';
 import { useSignOut } from '@/app/hooks/useSignOut';
 import { useRouter } from 'next/navigation';
 import { useStore } from '@/app/store';
-import { useFetchMember } from '@/app/hooks/useFetchMember';
 
 const navItemsWithAdmin = {
   Form: './form',
@@ -18,8 +17,7 @@ export const NavHeader = () => {
   const { signOut } = useSignOut();
   const router = useRouter();
   const loginUser = useStore((state) => state.loginUser.email);
-  const { data } = useFetchMember({ email: loginUser });
-  const auth = data.data?.[0]?.admin;
+  const loginAuth = useStore((state) => state.loginUser.auth);
 
   const onSubmit = async () => {
     const out = await signOut();
@@ -32,7 +30,7 @@ export const NavHeader = () => {
   };
   return (
     <Header
-      links={auth ? navItemsWithAdmin : navItemsWithMember}
+      links={loginAuth ? navItemsWithAdmin : navItemsWithMember}
       onClick={onSubmit}
       loginUser={loginUser}
     />

--- a/app/hooks/useFetchMember.ts
+++ b/app/hooks/useFetchMember.ts
@@ -1,5 +1,19 @@
 import { supabase } from '@/app/libs/supabase';
-import useSWR from 'swr';
+import { mutate } from 'swr';
+import { PostgrestError } from '@supabase/supabase-js';
+
+type ReturnProps = {
+  result:
+    | {
+        data:
+          | {
+              admin: boolean;
+            }[]
+          | null;
+        error: PostgrestError | null;
+      }
+    | undefined;
+};
 
 const fetcher = async ({ email }: { email: string | null }) => {
   try {
@@ -11,15 +25,14 @@ const fetcher = async ({ email }: { email: string | null }) => {
   }
 };
 
-export const useFetchMember = ({ email }: { email: string | null }) => {
-  const { data, error, isLoading } = useSWR('member_list', () => fetcher({ email }), {
-    suspense: true,
-    fallbackData: { data: null, error: null },
-  });
-
+export const useFetchMember = () => {
+  const fetchAuth = async ({ email }: { email: string | null }): Promise<ReturnProps> => {
+    const result = await mutate(`admin_auth_${email}`, fetcher({ email }));
+    return {
+      result,
+    };
+  };
   return {
-    data,
-    error,
-    isLoading,
+    fetchAuth,
   };
 };

--- a/app/libs/supabaseListener.tsx
+++ b/app/libs/supabaseListener.tsx
@@ -3,27 +3,38 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/app/libs/supabase';
 import { useStore } from '@/app/store';
+import { useFetchMember } from '@/app/hooks/useFetchMember';
 
 const SupabaseListener: React.FC<{ accessToken?: string }> = ({ accessToken }) => {
   const router = useRouter();
   const { updateLoginUser } = useStore();
+  const { fetchAuth } = useFetchMember();
 
   useEffect(() => {
     const getUserInfo = async () => {
       const { data } = await supabase.auth.getSession();
+      const auth = await fetchAuth({ email: data.session?.user.email || null });
 
       if (data.session) {
         updateLoginUser({
           id: data.session?.user.id,
           email: data.session?.user.email!,
+          auth: auth.result?.data?.[0]?.admin!,
         });
       }
     };
     getUserInfo();
-    supabase.auth.onAuthStateChange((_, session) => {
-      updateLoginUser({ id: session?.user.id!, email: session?.user.email! });
+    supabase.auth.onAuthStateChange(async (_, session) => {
+      const auth = await fetchAuth({ email: session?.user.email || null });
+
+      updateLoginUser({
+        id: session?.user.id!,
+        email: session?.user.email!,
+        auth: auth.result?.data?.[0]?.admin!,
+      });
       if (session?.access_token !== accessToken) router.refresh();
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accessToken, router, updateLoginUser]);
 
   return null;

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 type LoginUser = {
   id: string | null;
   email: string | null;
+  auth: boolean | undefined;
 };
 
 type State = {
@@ -15,7 +16,8 @@ export const useStore = create<State>((set) => ({
   loginUser: {
     id: '',
     email: '',
+    auth: undefined,
   },
   updateLoginUser: (payload) => set({ loginUser: payload }),
-  resetLoginUser: () => set({ loginUser: { id: '', email: '' } }),
+  resetLoginUser: () => set({ loginUser: { id: '', email: '', auth: undefined } }),
 }));


### PR DESCRIPTION
- `useFetchMember`を`mutate`で取得するように改修
- Adminの状態は`supabaseListener`にて、`useFetchMember`を取得し状態を管理
- Adminでないアカウントの場合、ログイン後はdashboardへ遷移する