### PR TITLE
fix: ログアウトがうまくできない問題を解消

### DIFF
--- a/app/(feature)/navHeader/index.tsx
+++ b/app/(feature)/navHeader/index.tsx
@@ -16,23 +16,25 @@ const navItemsWithMember = {
 export const NavHeader = () => {
   const { signOut } = useSignOut();
   const router = useRouter();
-  const loginUser = useStore((state) => state.loginUser.email);
-  const loginAuth = useStore((state) => state.loginUser.auth);
+  const { loginUser, updateLoginUser } = useStore((state) => state);
 
   const onSubmit = async () => {
-    const out = await signOut();
-    if (out?.error) {
+    try {
+      // FIXME: 本来は、signOutが成功してからrouter.refresh()を実行するべきだが、帰り値がないため判定ができない
+      router.refresh();
+      updateLoginUser({ id: '', email: '', auth: undefined });
+      await signOut();
+    } catch (e) {
       // eslint-disable-next-line no-alert
       alert('ログアウトに失敗しました。');
-    } else {
-      router.replace('/login');
     }
   };
+
   return (
     <Header
-      links={loginAuth ? navItemsWithAdmin : navItemsWithMember}
+      links={loginUser.auth ? navItemsWithAdmin : navItemsWithMember}
       onClick={onSubmit}
-      loginUser={loginUser}
+      loginUser={loginUser.email}
     />
   );
 };

--- a/app/hooks/useSignOut.test.ts
+++ b/app/hooks/useSignOut.test.ts
@@ -13,7 +13,7 @@ describe('useSignOut', () => {
     jest.spyOn(Supabase.supabase.auth, 'signOut').mockResolvedValueOnce({ error: null });
     const { result } = renderHook(() => useSignOut());
 
-    await expect(result.current.signOut()).resolves.toMatchObject({ error: null });
+    await expect(result.current.signOut()).resolves.toStrictEqual({ error: null });
   });
 
   test('SignOutがエラーの場合、errorのオブジェクトが返る', async () => {
@@ -28,6 +28,6 @@ describe('useSignOut', () => {
     jest.spyOn(Supabase.supabase.auth, 'signOut').mockRejectedValueOnce({ ...error });
     const { result } = renderHook(() => useSignOut());
 
-    await expect(result.current.signOut()).rejects.toMatchObject({ ...error });
+    await expect(result.current.signOut()).rejects.toStrictEqual({ ...error });
   });
 });

--- a/app/hooks/useSignOut.ts
+++ b/app/hooks/useSignOut.ts
@@ -2,10 +2,9 @@ import { supabase } from '@/app/libs/supabase';
 
 export const useSignOut = () => {
   const signOut = async () => {
-    const error = await supabase.auth.signOut();
-    if (error) {
-      return error;
-    }
+    const { error } = await supabase.auth.signOut();
+
+    return { error };
   };
 
   return { signOut };

--- a/middleware.tsx
+++ b/middleware.tsx
@@ -56,10 +56,13 @@ export async function middleware(req: NextRequest) {
 
   const { data } = await supabase.auth.getUser();
 
+  const pathNames = ['/form', '/dashboard'];
+  const accessPath = pathNames.some((path) => req.nextUrl.pathname.startsWith(path));
+
   if (
     // eslint-disable-next-line operator-linebreak
-    (!data.user && req.nextUrl.pathname.startsWith('/form')) ||
-    (!data.user && req.nextUrl.pathname.startsWith('/dashboard'))
+    !data.user &&
+    accessPath
   ) {
     const redirectUrl = req.nextUrl.clone();
     redirectUrl.pathname = '/login';


### PR DESCRIPTION
- ログアウトしても返り値がとれないため、一時的にrefreshとstoreを先にクリア（`@supabase/ssr`でするとそうなる）
- `middleware`でログイン無しにform、dashboardにアクセスする場合の処理をリファクタリング
- `useSignOut`の実装を修正
- 上記の改修におけるUTを修正