### PR TITLE
test: カスタムhooksのUTで、アサーションを`toStrictEqual`へ変更

### DIFF
--- a/app/hooks/useFetchMember.test.ts
+++ b/app/hooks/useFetchMember.test.ts
@@ -37,7 +37,7 @@ describe('useFetchMember', () => {
     jest.spyOn(result.current, 'fetchAuth').mockResolvedValueOnce({ ...mockSuccessResponse });
 
     const response = await result.current.fetchAuth({ email: 'test@test.com' });
-    expect(response).toEqual({
+    expect(response).toStrictEqual({
       ...mockSuccessResponse,
     });
   });
@@ -49,7 +49,7 @@ describe('useFetchMember', () => {
     });
 
     const response = await result.current.fetchAuth({ email: 'test@test.com' });
-    expect(response).toEqual({
+    expect(response).toStrictEqual({
       ...mockErrorResponse,
     });
   });

--- a/app/hooks/useFetchPricesList.test.ts
+++ b/app/hooks/useFetchPricesList.test.ts
@@ -38,7 +38,7 @@ describe('useFetchPricesList', () => {
     await waitFor(() => {
       expect(result.current?.isLoading).toBe(false);
       expect(result.current?.error).toBeNull();
-      expect(result.current?.data).toEqual([
+      expect(result.current?.data).toStrictEqual([
         {
           created_at: '2024-02-23T12:00:00.000Z',
           help: 'Some help',

--- a/app/hooks/useSignIn.test.ts
+++ b/app/hooks/useSignIn.test.ts
@@ -48,7 +48,7 @@ describe('useSignIn', () => {
     } as unknown as AuthError);
     const { result } = renderHook(() => useSignIn());
 
-    await expect(result.current.signIn(mockArgs)).rejects.toMatchObject({
+    await expect(result.current.signIn(mockArgs)).rejects.toStrictEqual({
       ...error,
     });
   });


### PR DESCRIPTION
- `toStrictEqual`へ変更できる箇所を修正
- 上記変更することにより、UTをより厳格にできる