### PR TITLE
fix: ログイン状態でないと、ヘッダーメニューが表示されないように改修

### DIFF
--- a/app/(feature)/navHeader/indext.test.tsx
+++ b/app/(feature)/navHeader/indext.test.tsx
@@ -39,7 +39,7 @@ describe('NavHeader', () => {
     jest.clearAllMocks();
   });
 
-  test('NavHeaderがレンダリングされる', () => {
+  test('NavHeaderがレンダリングされタイトルの文字列が取得できる', () => {
     jest.spyOn(Zustand, 'useStore').mockImplementation(
       (state) =>
         state({
@@ -49,7 +49,7 @@ describe('NavHeader', () => {
         }) || {},
     );
     render(<NavHeader />);
-    expect(screen.getByRole('link', { name: 'Login' })).toBeInTheDocument();
+    expect(screen.getByText('Record of help')).toBeInTheDocument();
   });
 
   test('Logoutをクリックするとloginページのreplaceされる', async () => {

--- a/app/components/Header/index.test.tsx
+++ b/app/components/Header/index.test.tsx
@@ -9,9 +9,17 @@ const mockNavItems: NavAdminType = {
   Dashboard: './dashboard',
 };
 
+const mockLoginUser = 'test@test.com';
+
+const mockData = {
+  links: mockNavItems,
+  loginUser: mockLoginUser,
+  onClick: jest.fn(),
+};
+
 describe('Header', () => {
   test('Headerのタイトルがレンダーされる', () => {
-    render(<Header links={mockNavItems} onClick={jest.fn()} />);
+    render(<Header {...mockData} />);
     const headerComponent = screen.getByText(headerText);
     expect(headerComponent).toBeInTheDocument();
   });
@@ -21,18 +29,16 @@ describe('Header', () => {
     ${'Form'}      | ${'./form'}      | ${(<a href="./form">Form</a>)}
     ${'Dashboard'} | ${'./dashboard'} | ${(<a href="./dashboard">Dashboard</a>)}
   `('HeaderのnavとなるLinkがそれぞれ対応するhref属性をもつ', ({ linkName, href }) => {
-    render(<Header links={mockNavItems} onClick={jest.fn()} />);
+    render(<Header {...mockData} />);
     const link = screen.getByRole('link', { name: linkName });
     expect(link).toHaveAttribute('href', href);
   });
 
   test('Logoutをクリックすると、propsで渡したonClick関数が1回実行される', async () => {
-    const mockOnClick = jest.fn();
-    const mockLoginUser = 'test@test.com';
-    render(<Header links={mockNavItems} onClick={mockOnClick} loginUser={mockLoginUser} />);
+    render(<Header {...mockData} />);
     const logout = screen.getByText(mockLoginUser);
     const user = userEvent.setup();
     await user.click(logout);
-    expect(mockOnClick).toHaveBeenCalledTimes(1);
+    expect(mockData.onClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -67,24 +67,26 @@ export const Header = ({
             className={`${!menuOpen ? 'hidden' : 'block'} ${headerStyles.hamburgerContainer}`}
             id="navbar-default"
           >
-            <ul className={headerStyles.menuUlStyle}>
-              {Object.keys(links).map((link) => (
-                <li key={link} className={headerStyles.menuLiStyle}>
-                  <Link
-                    className={headerStyles.menuLink}
-                    href={links[link as keyof typeof links]}
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    {link}
+            {loginUser && (
+              <ul className={headerStyles.menuUlStyle}>
+                {Object.keys(links).map((link) => (
+                  <li key={link} className={headerStyles.menuLiStyle}>
+                    <Link
+                      className={headerStyles.menuLink}
+                      href={links[link as keyof typeof links]}
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      {link}
+                    </Link>
+                  </li>
+                ))}
+                <li className={headerStyles.menuLiStyle}>
+                  <Link href="#" className={headerStyles.menuLink} onClick={onClick}>
+                    {loginUser}
                   </Link>
                 </li>
-              ))}
-              <li className={headerStyles.menuLiStyle}>
-                <Link href="#" className={headerStyles.menuLink} onClick={onClick}>
-                  {loginUser || 'Login'}
-                </Link>
-              </li>
-            </ul>
+              </ul>
+            )}
           </div>
         </div>
       </nav>


### PR DESCRIPTION
- 未ログイン時のヘッダーはアプリのタイトルのみ表示
- ログイン状態でそのAuthに応じてメニューが表示される
- 上記改修によるUTも修正