### PR TITLE
test: 各Storybookのファイルから不要な`render`を削除

### DIFF
--- a/app/(feature)/dashboard/components/DashboardTable/index.stories.tsx
+++ b/app/(feature)/dashboard/components/DashboardTable/index.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { StoryObj, Meta } from '@storybook/react';
 import { DashboardTable, Props } from '.';
 
@@ -48,5 +47,4 @@ const mockTdData: Props = [
 
 export const Default: Story = {
   args: { th: mockThData, td: mockTdData },
-  render: (args) => <DashboardTable {...args} />,
 };

--- a/app/(feature)/dashboard/index.stories.tsx
+++ b/app/(feature)/dashboard/index.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { StoryObj, Meta } from '@storybook/react';
 import Page from './page';
 
@@ -9,6 +8,4 @@ export default {
 
 type Story = StoryObj<typeof Page>;
 
-export const Default: Story = {
-  render: () => <Page />,
-};
+export const Default: Story = {};

--- a/app/(feature)/form/index.stories.tsx
+++ b/app/(feature)/form/index.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Page from './page';
 import { StoryObj, Meta } from '@storybook/react';
 
@@ -17,6 +16,4 @@ export default {
 
 type Story = StoryObj<typeof Page>;
 
-export const Default: Story = {
-  render: () => <Page />,
-};
+export const Default: Story = {};

--- a/app/(feature)/login/index.stories.tsx
+++ b/app/(feature)/login/index.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Page from './page';
 import { StoryObj, Meta } from '@storybook/react';
 
@@ -17,6 +16,4 @@ export default {
 
 type Story = StoryObj<typeof Page>;
 
-export const Default: Story = {
-  render: () => <Page />,
-};
+export const Default: Story = {};

--- a/app/(feature)/navHeader/index.stories.tsx
+++ b/app/(feature)/navHeader/index.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { NavHeader } from '.';
+import { StoryObj, Meta } from '@storybook/react';
 
 export default {
   title: 'app/feature/NavHeader',
@@ -9,8 +9,8 @@ export default {
       appDirectory: true,
     },
   },
-};
+} as Meta<typeof NavHeader>;
 
-export const Default = (): JSX.Element => {
-  return <NavHeader />;
-};
+export type Story = StoryObj<typeof NavHeader>;
+
+export const Default: Story = {};

--- a/app/components/Button/index.stories.tsx
+++ b/app/components/Button/index.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Button, Props } from '.';
 import { StoryObj, Meta } from '@storybook/react';
 
@@ -19,15 +18,12 @@ const mockBaseData: Props = {
 
 export const Default: Story = {
   args: mockBaseData,
-  render: (args) => <Button {...args} />,
 };
 
 export const Disabled: Story = {
   args: { ...mockBaseData, disabled: true },
-  render: (args) => <Button {...args} />,
 };
 
 export const Secondary: Story = {
   args: { ...mockBaseData, style: 'secondary' },
-  render: (args) => <Button {...args} />,
 };

--- a/app/components/Checkbox/index.stories.tsx
+++ b/app/components/Checkbox/index.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Checkbox } from '.';
 import { StoryObj, Meta } from '@storybook/react';
 
@@ -16,5 +15,4 @@ export const Default: Story = {
     value: 'checkbox value',
     ref: null,
   },
-  render: (args) => <Checkbox {...args} />,
 };

--- a/app/components/Header/index.stories.tsx
+++ b/app/components/Header/index.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Header, NavAdminType, NavMemberType } from '.';
 import { StoryObj, Meta } from '@storybook/react';
 
@@ -24,7 +23,6 @@ export const Admin: Story = {
     onClick: () => {},
     loginUser: 'test@test.com',
   },
-  render: (args) => <Header {...args} />,
 };
 
 export const Member: Story = {
@@ -33,7 +31,6 @@ export const Member: Story = {
     onClick: () => {},
     loginUser: 'test@test.com',
   },
-  render: (args) => <Header {...args} />,
 };
 
 export const NotLogin: Story = {

--- a/app/components/Input/index.stories.tsx
+++ b/app/components/Input/index.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Input, Props } from '.';
 import { StoryObj, Meta } from '@storybook/react';
 
@@ -18,20 +17,16 @@ const baseMockData: Props = {
 
 export const Default: Story = {
   args: { ...baseMockData, disabled: false },
-  render: (args) => <Input {...args} />,
 };
 
 export const Password: Story = {
   args: { ...baseMockData, type: 'password', disabled: false },
-  render: (args) => <Input {...args} />,
 };
 
 export const Date: Story = {
   args: { ...baseMockData, type: 'date', disabled: false },
-  render: (args) => <Input {...args} />,
 };
 
 export const Disabled: Story = {
   args: { ...baseMockData, disabled: true },
-  render: (args) => <Input {...args} />,
 };

--- a/app/components/Radio/index.stories.tsx
+++ b/app/components/Radio/index.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Radio, Props } from '.';
 import { StoryObj, Meta } from '@storybook/react';
 
@@ -17,5 +16,4 @@ const mockData: Props = {
 
 export const Default: Story = {
   args: mockData,
-  render: (args) => <Radio {...args} />,
 };

--- a/app/components/SelectBox/index.stories.tsx
+++ b/app/components/SelectBox/index.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { SelectBox, Props } from '.';
 import { StoryObj, Meta } from '@storybook/react';
 
@@ -21,7 +20,6 @@ export const Default: Story = {
     label: '選択してください',
     options: mockOptions,
   },
-  render: (args) => <SelectBox {...args} />,
 };
 
 export const Disabled: Story = {
@@ -31,5 +29,4 @@ export const Disabled: Story = {
     options: mockOptions,
     isDisabled: true,
   },
-  render: (args) => <SelectBox {...args} />,
 };

--- a/app/components/Table/index.stories.tsx
+++ b/app/components/Table/index.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Table, Props } from '.';
 import { StoryObj, Meta } from '@storybook/react';
 
@@ -91,15 +90,12 @@ const mockTdDataDiff: Props = [
 
 export const Default: Story = {
   args: { thData: mockThData, tdData: mockTdData },
-  render: (args) => <Table {...args} />,
 };
 
 export const DifferentThAndTdLength: Story = {
   args: { thData: mockThData, tdData: mockTdDataDiff },
-  render: (args) => <Table {...args} />,
 };
 
 export const Null: Story = {
   args: { thData: mockThData, tdData: null },
-  render: (args) => <Table {...args} />,
 };

--- a/app/components/Textarea/index.stories.tsx
+++ b/app/components/Textarea/index.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Textarea, Props } from '.';
 import { StoryObj, Meta } from '@storybook/react';
 
@@ -17,5 +16,4 @@ const mockData: Props = {
 
 export const Default: Story = {
   args: mockData,
-  render: (args) => <Textarea {...args} />,
 };


### PR DESCRIPTION
- `render`を記述せずともも表示できるものは`render`の記述箇所を削除
- 上記に伴いReactの`import`も不要になるため削除