### PR TITLE
feat: フォームが入力済みで離脱しようとする場合、`confirm`が表示される

### DIFF
--- a/app/(feature)/form/hooks/useLeavingModal/index.ts
+++ b/app/(feature)/form/hooks/useLeavingModal/index.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+
+export const useLeavingModal = (isDirty: boolean) => {
+  // NOTE: 閉じる、リロード、ブラウザバック
+  const handleBeforeunload = (e: BeforeUnloadEvent) => {
+    e.preventDefault();
+  };
+
+  // NOTE: リンククリック
+  const handleClick = (event: MouseEvent) => {
+    const targetElement = event.target as HTMLElement;
+
+    if (isDirty && targetElement.tagName === 'A') {
+      // eslint-disable-next-line no-alert
+      if (!window.confirm('ページを離れても良いですか？')) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (!isDirty) return;
+    window.addEventListener('beforeunload', handleBeforeunload);
+    window.addEventListener('click', handleClick, true);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeunload);
+      window.removeEventListener('click', handleClick, true);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDirty]);
+
+  return null;
+};

--- a/app/(feature)/form/page.tsx
+++ b/app/(feature)/form/page.tsx
@@ -11,6 +11,7 @@ import { Textarea } from '@/app/components/Textarea';
 import { convertHelps } from './helper/convertHelps';
 import { usePostHelp } from '@/app/(feature)/form/hooks/usePostHelp';
 import { PricesList } from './components/PricesList';
+import { useLeavingModal } from '@/app/(feature)/form/hooks/useLeavingModal';
 
 export type Props = {
   person: string;
@@ -52,13 +53,15 @@ export default function Page() {
 
   const {
     register,
-    formState: { errors },
+    formState: { errors, isDirty },
     handleSubmit,
     control,
   } = useForm<Props>({
     mode: 'onChange',
     resolver: zodResolver(validationSchema),
   });
+
+  useLeavingModal(isDirty);
 
   return (
     isClient && (


### PR DESCRIPTION
- ブラウザバック、リロード、クローズの場合
- App内部リンクへの離脱
- 上記各々でハンドリングするhookを追加
- UTは後日追加する