### PR TITLE
test: フォームにレンダリングされるお手伝いリストのUTを追加

### DIFF
--- a/app/(feature)/form/components/PricesList/index.test.tsx
+++ b/app/(feature)/form/components/PricesList/index.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PricesList } from '@/app/(feature)/form/components/PricesList';
+import { useFetchPricesList } from '@/app/(feature)/form/hooks/useFetchPricesList';
+import { UseFormRegisterReturn } from 'react-hook-form';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('../../hooks/useFetchPricesList');
+const mockedUseFetchPricesList = jest.mocked(useFetchPricesList);
+
+const mockData = {
+  data: [
+    {
+      created_at: '2024-02-03T05:45:49.781887+00:00',
+      update_at: null,
+      help: 'dish',
+      id: 'd0d28f25',
+      label: '皿洗い',
+      prices_list: [
+        {
+          created_at: '2024-02-03T05:48:32.3764+00:00',
+          help_id: 'd0d28f25',
+          id: 1,
+          price: 30,
+          update_at: null,
+        },
+      ],
+    },
+  ],
+  error: null,
+};
+
+const mockFailedData = {
+  data: [],
+  error: { message: 'string', details: 'string', hint: 'string', code: 'string' },
+};
+
+describe('PricesList', () => {
+  const user = userEvent.setup();
+
+  const register = {
+    onChange: jest.fn(),
+    onBlur: jest.fn(),
+    ref: jest.fn(),
+    name: 'items.helps',
+  } as UseFormRegisterReturn<'items.helps'>;
+
+  test('hooksからリストのデータが変える場合、チェックボックスがレンダリングされる', async () => {
+    mockedUseFetchPricesList.mockReturnValue(mockData);
+
+    render(<PricesList register={register} />);
+
+    const checkbox = screen.getByLabelText('皿洗い');
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toHaveAttribute('type', 'checkbox');
+  });
+
+  test('hooksからエラーが返る場合、チェックボックスがレンダリングされない', async () => {
+    mockedUseFetchPricesList.mockReturnValue(mockFailedData);
+    render(<PricesList register={register} />);
+
+    const checkbox = screen.queryByLabelText('皿洗い');
+    expect(checkbox).not.toBeInTheDocument();
+  });
+
+  test('hooksからリストのデータが変える場合、チェックボックスがクリックでチェックできる', async () => {
+    mockedUseFetchPricesList.mockReturnValue(mockData);
+
+    render(<PricesList register={register} />);
+
+    const checkbox = screen.getByLabelText('皿洗い');
+    expect(checkbox).toBeInTheDocument();
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+  });
+});

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -15,5 +15,5 @@ export type PricesHelpsList = {
       update_at: string | null;
     }[];
   }[];
-  error: PostgrestError;
+  error: PostgrestError | null;
 };


### PR DESCRIPTION
- `PricesHelpsList`のエラーの型にユニオンで`null`を追加（実際も成功時はnullが返る）
- `pricesHelpsList`のUTを追加