### PR TITLE
refactor: e2eのテストを最適化

### DIFF
--- a/tests/leavingModal.spec.ts
+++ b/tests/leavingModal.spec.ts
@@ -3,31 +3,28 @@ import { test, expect } from '@playwright/test';
 const email = process.env.EMAIL as string;
 const password = process.env.PASSWORD as string;
 
-const LoginToForm = async (page: any, baseURL?: string) => {
-  await page.goto(`${baseURL}login`);
-  await page.getByRole('textbox', { name: 'メールアドレス' }).fill(email);
-  await page.getByRole('textbox', { name: 'パスワード' }).fill(password);
-  await page.getByRole('button', { name: 'ログイン' }).click();
-  await page.getByRole('link', { name: 'Form' }).click();
-};
-
-test('フォームを入力し、離脱しようとするとconfirmが表示される', async ({ page, baseURL }) => {
-  await LoginToForm(page, baseURL);
-
-  await page.getByLabel('eito').check();
-  await page.getByRole('link', { name: 'Dashboard' }).click();
-
-  page.on('dialog', (dialog) => {
-    expect(dialog.message()).toContain('ページを離れても良いですか？');
+test.describe('離脱する場合のテスト', () => {
+  test.beforeEach(async ({ page, baseURL }) => {
+    await page.goto(`${baseURL}login`);
+    await page.getByRole('textbox', { name: 'メールアドレス' }).fill(email);
+    await page.getByRole('textbox', { name: 'パスワード' }).fill(password);
+    await page.getByRole('button', { name: 'ログイン' }).click();
+    await page.getByRole('link', { name: 'Form' }).click();
   });
-});
+  test('フォームを入力し、離脱しようとするとconfirmが表示される', async ({ page }) => {
+    await page.getByLabel('eito').check();
+    await page.getByRole('link', { name: 'Dashboard' }).click();
 
-test('フォームを入力せず、離脱しようとするとconfirmは表示されない', async ({ page, baseURL }) => {
-  await LoginToForm(page, baseURL);
+    page.on('dialog', (dialog) => {
+      expect(dialog.message()).toContain('ページを離れても良いですか？');
+    });
+  });
 
-  await page.getByRole('link', { name: 'Dashboard' }).click();
+  test('フォームを入力せず、離脱しようとするとconfirmは表示されない', async ({ page }) => {
+    await page.getByRole('link', { name: 'Dashboard' }).click();
 
-  page.on('dialog', (dialog) => {
-    expect(dialog.message()).not.toContain('ページを離れても良いですか？');
+    page.on('dialog', (dialog) => {
+      expect(dialog.message()).not.toContain('ページを離れても良いですか？');
+    });
   });
 });

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -3,36 +3,38 @@ import { test, expect } from '@playwright/test';
 const email = process.env.EMAIL as string;
 const password = process.env.PASSWORD as string;
 
-test('ドメイン名でアクセスすると、タイトル、ログインページへの遷移リンクが表示される', async ({
-  page,
-  baseURL,
-}) => {
-  await page.goto(`${baseURL}`);
+test.describe('ログインのテスト', () => {
+  test('ドメイン名でアクセスすると、タイトル、ログインページへの遷移リンクが表示される', async ({
+    page,
+    baseURL,
+  }) => {
+    await page.goto(`${baseURL}`);
 
-  await expect(page).toHaveTitle(/Record of Help/);
-  await expect(page.getByRole('link', { name: 'Go to Login Page' })).toBeVisible();
-});
+    await expect(page).toHaveTitle(/Record of Help/);
+    await expect(page.getByRole('link', { name: 'Go to Login Page' })).toBeVisible();
+  });
 
-test('ログインページへの遷移するとメールアドレスとパスワードの入力欄が表示される', async ({
-  page,
-  baseURL,
-}) => {
-  await page.goto(`${baseURL}`);
-  await page.getByRole('link', { name: 'Go to Login Page' }).click();
+  test('ログインページへの遷移するとメールアドレスとパスワードの入力欄が表示される', async ({
+    page,
+    baseURL,
+  }) => {
+    await page.goto(`${baseURL}`);
+    await page.getByRole('link', { name: 'Go to Login Page' }).click();
 
-  await expect(page.getByRole('textbox', { name: 'メールアドレス' })).toBeVisible();
-  await expect(page.getByRole('textbox', { name: 'パスワード' })).toBeVisible();
-});
+    await expect(page.getByRole('textbox', { name: 'メールアドレス' })).toBeVisible();
+    await expect(page.getByRole('textbox', { name: 'パスワード' })).toBeVisible();
+  });
 
-test('ログインするとヘッダーのリンクが表示される', async ({ page, baseURL }) => {
-  await page.goto(`${baseURL}login`);
+  test('ログインするとヘッダーのリンクが表示される', async ({ page, baseURL }) => {
+    await page.goto(`${baseURL}login`);
 
-  await page.getByRole('textbox', { name: 'メールアドレス' }).fill(email);
-  await page.getByRole('textbox', { name: 'パスワード' }).fill(password);
-  await page.getByRole('button', { name: 'ログイン' }).click();
+    await page.getByRole('textbox', { name: 'メールアドレス' }).fill(email);
+    await page.getByRole('textbox', { name: 'パスワード' }).fill(password);
+    await page.getByRole('button', { name: 'ログイン' }).click();
 
-  await expect(page.getByRole('link', { name: 'Form' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Dashboard' })).toBeVisible();
-  await expect(page.getByText(email)).toBeVisible();
-  await expect(page).toHaveURL(`${baseURL}dashboard`);
+    await expect(page.getByRole('link', { name: 'Form' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Dashboard' })).toBeVisible();
+    await expect(page.getByText(email)).toBeVisible();
+    await expect(page).toHaveURL(`${baseURL}dashboard`);
+  });
 });

--- a/tests/screenTransition.spec.ts
+++ b/tests/screenTransition.spec.ts
@@ -1,44 +1,43 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 const email = process.env.EMAIL as string;
 const password = process.env.PASSWORD as string;
 
-const login = async ({ page, baseURL }: { page: Page; baseURL: string }) => {
-  await page.goto(`${baseURL}login`);
+test.describe('画面遷移のテスト', () => {
+  test.beforeEach(async ({ page, baseURL }) => {
+    await page.goto(`${baseURL}login`);
 
-  await page.getByRole('textbox', { name: 'メールアドレス' }).fill(email);
-  await page.getByRole('textbox', { name: 'パスワード' }).fill(password);
-  await page.getByRole('button', { name: 'ログイン' }).click();
+    await page.getByRole('textbox', { name: 'メールアドレス' }).fill(email);
+    await page.getByRole('textbox', { name: 'パスワード' }).fill(password);
+    await page.getByRole('button', { name: 'ログイン' }).click();
 
-  await expect(page.getByRole('link', { name: 'Form' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Dashboard' })).toBeVisible();
-  await expect(page.getByText(email)).toBeVisible();
-  await expect(page).toHaveURL(`${baseURL}dashboard`);
-};
+    await expect(page.getByRole('link', { name: 'Form' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Dashboard' })).toBeVisible();
+    await expect(page.getByText(email)).toBeVisible();
+    await expect(page).toHaveURL(`${baseURL}dashboard`);
+  });
+  test('トップページから、Go to Login Pageをクリックするとloginへ遷移する', async ({
+    page,
+    baseURL,
+  }) => {
+    await page.goto(`${baseURL}`);
+    await page.getByRole('link', { name: 'Go to Login Page' }).click();
+    await expect(page).toHaveURL(`${baseURL}login`);
+  });
 
-test('トップページから、Go to Login Pageをクリックするとloginへ遷移する', async ({
-  page,
-  baseURL,
-}) => {
-  await page.goto(`${baseURL}`);
-  await page.getByRole('link', { name: 'Go to Login Page' }).click();
-  await expect(page).toHaveURL(`${baseURL}login`);
-});
+  test('ログイン後、ナビゲーションのFormをクリックするとformへ遷移する', async ({
+    page,
+    baseURL,
+  }) => {
+    await page.getByRole('link', { name: 'Form' }).click();
+    await expect(page).toHaveURL(`${baseURL}form`);
+  });
 
-test('ログイン後、ナビゲーションのFormをクリックするとformへ遷移する', async ({
-  page,
-  baseURL,
-}) => {
-  await login({ page, baseURL: baseURL ?? '' });
-  await page.getByRole('link', { name: 'Form' }).click();
-  await expect(page).toHaveURL(`${baseURL}form`);
-});
-
-test('ログイン後、ナビゲーションのDashboardをクリックするとdashboardへ遷移する', async ({
-  page,
-  baseURL,
-}) => {
-  await login({ page, baseURL: baseURL ?? '' });
-  await page.getByRole('link', { name: 'Dashboard' }).click();
-  await expect(page).toHaveURL(`${baseURL}dashboard`);
+  test('ログイン後、ナビゲーションのDashboardをクリックするとdashboardへ遷移する', async ({
+    page,
+    baseURL,
+  }) => {
+    await page.getByRole('link', { name: 'Dashboard' }).click();
+    await expect(page).toHaveURL(`${baseURL}dashboard`);
+  });
 });


### PR DESCRIPTION
- 複数あるものは`describe`でラップしグループ化
- 前提処理を関数で実施していたところを`beforeEach`で実行するように変更