### PR TITLE
chore: StorybookのStoryに無駄に`render`されている箇所があったため削除

### DIFF
--- a/app/components/Header/index.stories.tsx
+++ b/app/components/Header/index.stories.tsx
@@ -38,5 +38,4 @@ export const NotLogin: Story = {
     links: mockNavMemberItems,
     onClick: () => {},
   },
-  render: (args) => <Header {...args} />,
 };


### PR DESCRIPTION
- なくても描画されるため削除