### PR TITLE
test: `render`からクエリ関数を取り出すように修正

### DIFF
--- a/app/(feature)/dashboard/components/DashboardTable/index.test.tsx
+++ b/app/(feature)/dashboard/components/DashboardTable/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { DashboardTable, Props } from '.';
 
 const mockThData = {
@@ -56,16 +56,18 @@ const mockTdDataWithDelFlag: Props = [
 
 describe('DashboardTable', () => {
   test('テーブルに2つの氏名が表示され、データにない氏名は表示されない', () => {
-    render(<DashboardTable th={mockThData} td={mockTdData} />);
-    expect(screen.getByText('eito')).toBeInTheDocument();
-    expect(screen.getByText('mei')).toBeInTheDocument();
-    expect(screen.queryByText('taro')).not.toBeInTheDocument();
+    const { getByText, queryByText } = render(<DashboardTable th={mockThData} td={mockTdData} />);
+    expect(getByText('eito')).toBeInTheDocument();
+    expect(getByText('mei')).toBeInTheDocument();
+    expect(queryByText('taro')).not.toBeInTheDocument();
   });
 
   test('2つのデータのうち、1つにdel_flag=trueのデータが渡された場合、テーブルに1つの氏名が表示される', () => {
-    render(<DashboardTable th={mockThData} td={mockTdDataWithDelFlag} />);
-    expect(screen.queryByText('eito')).not.toBeInTheDocument();
-    expect(screen.getByText('mei')).toBeInTheDocument();
+    const { getByText, queryByText } = render(
+      <DashboardTable th={mockThData} td={mockTdDataWithDelFlag} />,
+    );
+    expect(queryByText('eito')).not.toBeInTheDocument();
+    expect(getByText('mei')).toBeInTheDocument();
   });
 
   test('tdにnullが渡されるとコンポーネントが表示されない', () => {

--- a/app/(feature)/dashboard/index.test.tsx
+++ b/app/(feature)/dashboard/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { default as Dashboard } from './page';
 
@@ -13,15 +13,15 @@ describe('Dashboard', () => {
 
   describe('検索パネル', () => {
     test('SelectBoxが1つレンダリングされる', () => {
-      render(<Dashboard />);
-      const select = screen.getAllByRole('combobox');
+      const { getAllByRole } = render(<Dashboard />);
+      const select = getAllByRole('combobox');
       expect(select).toHaveLength(1);
     });
 
     test('Inputがdate属性で2つレンダリングされる', () => {
-      render(<Dashboard />);
-      const startInput = screen.getByLabelText('開始');
-      const endInput = screen.getByLabelText('終了');
+      const { getByLabelText } = render(<Dashboard />);
+      const startInput = getByLabelText('開始');
+      const endInput = getByLabelText('終了');
       [startInput, endInput].forEach((input) => {
         expect(input).toBeInTheDocument();
         expect(input).toHaveAttribute('type', 'date');
@@ -29,44 +29,44 @@ describe('Dashboard', () => {
     });
 
     test('Buttonがsubmit属性、Enabledで1つレンダリングされる', () => {
-      render(<Dashboard />);
-      const button = screen.getByRole('button', { name: '検索' });
+      const { getByRole } = render(<Dashboard />);
+      const button = getByRole('button', { name: '検索' });
       expect(button).toBeInTheDocument();
       expect(button).toHaveAttribute('type', 'submit');
       expect(button).toBeEnabled();
     });
 
     test('対象者を未選択、開始終了をクリアし検索ボタンを押すとvalidationエラーになる', async () => {
-      render(<Dashboard />);
+      const { getByRole, getByLabelText, getByText } = render(<Dashboard />);
       const validationsText = ['対象を選択', '開始日を選択', '終了日を選択'];
-      const button = screen.getByRole('button', { name: '検索' });
+      const button = getByRole('button', { name: '検索' });
 
-      const startInput = screen.getByLabelText('開始');
-      const endInput = screen.getByLabelText('終了');
+      const startInput = getByLabelText('開始');
+      const endInput = getByLabelText('終了');
 
       await user.clear(startInput);
       await user.clear(endInput);
       await user.click(button);
       validationsText.forEach((text) => {
-        expect(screen.getByText(text)).toBeInTheDocument();
+        expect(getByText(text)).toBeInTheDocument();
       });
     });
 
     describe('非表示/表示ボタン', () => {
       test('非表示のボタンがレンダリングされる', () => {
-        render(<Dashboard />);
-        const button = screen.getByRole('button', { name: '表示' });
+        const { getByRole } = render(<Dashboard />);
+        const button = getByRole('button', { name: '表示' });
         expect(button).toBeInTheDocument();
       });
 
       test('非表示のボタンをクリックすると検索パネルが表示される', async () => {
         const labelNames = ['対象者を選択', '開始', '終了', '検索', '表示'];
-        render(<Dashboard />);
-        const button = screen.getByRole('button', { name: '表示' });
+        const { getByRole, findByText } = render(<Dashboard />);
+        const button = getByRole('button', { name: '表示' });
 
         await user.click(button);
         labelNames.forEach(async (text) => {
-          expect(await screen.findByText(text)).toBeInTheDocument();
+          expect(await findByText(text)).toBeInTheDocument();
         });
       });
     });

--- a/app/(feature)/form/components/PricesList/index.test.tsx
+++ b/app/(feature)/form/components/PricesList/index.test.tsx
@@ -1,6 +1,6 @@
 import { PricesList } from '@/app/(feature)/form/components/PricesList';
 import { useFetchPricesList } from '@/app/(feature)/form/hooks/useFetchPricesList';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { UseFormRegisterReturn } from 'react-hook-form';
 
@@ -51,27 +51,27 @@ describe('PricesList', () => {
   test('hooksからリストのデータが変える場合、チェックボックスがレンダリングされる', () => {
     mockedUseFetchPricesList.mockReturnValue(mockData);
 
-    render(<PricesList register={register} />);
+    const { getByLabelText } = render(<PricesList register={register} />);
 
-    const checkbox = screen.getByLabelText('皿洗い');
+    const checkbox = getByLabelText('皿洗い');
     expect(checkbox).toBeInTheDocument();
     expect(checkbox).toHaveAttribute('type', 'checkbox');
   });
 
   test('hooksからエラーが返る場合、チェックボックスがレンダリングされない', () => {
     mockedUseFetchPricesList.mockReturnValue(mockFailedData);
-    render(<PricesList register={register} />);
+    const { queryByLabelText } = render(<PricesList register={register} />);
 
-    const checkbox = screen.queryByLabelText('皿洗い');
+    const checkbox = queryByLabelText('皿洗い');
     expect(checkbox).not.toBeInTheDocument();
   });
 
   test('hooksからリストのデータが変える場合、チェックボックスがクリックでチェックを入れ外しできる', async () => {
     mockedUseFetchPricesList.mockReturnValue(mockData);
 
-    render(<PricesList register={register} />);
+    const { getByLabelText } = render(<PricesList register={register} />);
 
-    const checkbox = screen.getByLabelText('皿洗い');
+    const checkbox = getByLabelText('皿洗い');
     expect(checkbox).toBeInTheDocument();
     await user.click(checkbox);
     expect(checkbox).toBeChecked();

--- a/app/(feature)/form/hooks/useFetchPricesList/index.ts
+++ b/app/(feature)/form/hooks/useFetchPricesList/index.ts
@@ -2,18 +2,10 @@ import { supabase } from '@/app/libs/supabase';
 import { PricesHelpsList } from '@/app/types';
 import useSWR from 'swr';
 
-const fetcher = async () => {
-  try {
-    const fetchSupabase = () => supabase.from('helps_list').select('*, prices_list (*)');
-    const { data, error } = await fetchSupabase();
-    return { data, error };
-  } catch (error) {
-    throw new Error(String(error));
-  }
-};
+const fetchSupabase = () => supabase.from('helps_list').select('*, prices_list (*)');
 
 export const useFetchPricesList = (): PricesHelpsList | undefined => {
-  const { data, error } = useSWR('helps_list_and_prices_list', fetcher, {
+  const { data, error } = useSWR('helps_list_and_prices_list', fetchSupabase, {
     suspense: true,
   });
 

--- a/app/(feature)/form/hooks/useLeavingModal/index.test.tsx
+++ b/app/(feature)/form/hooks/useLeavingModal/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, renderHook, screen } from '@testing-library/react';
+import { render, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useForm } from 'react-hook-form';
 import { useLeavingModal } from '.';
@@ -20,11 +20,11 @@ const renderForm = () => {
     );
   };
 
-  render(<WrapperComponent />);
+  const { getByRole } = render(<WrapperComponent />);
 
   return {
-    input: screen.getByRole('textbox'),
-    link: screen.getByRole('link'),
+    input: getByRole('textbox'),
+    link: getByRole('link'),
   };
 };
 

--- a/app/(feature)/form/index.test.tsx
+++ b/app/(feature)/form/index.test.tsx
@@ -1,5 +1,5 @@
 import { mockPricesListRaw } from '@/mocks/pricesList';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useFetchPricesList } from './hooks/useFetchPricesList';
 import { default as Form } from './page';
@@ -22,9 +22,9 @@ describe('Form', () => {
 
   describe('radio', () => {
     test('radioボタンが2つレンダリングされる', () => {
-      render(<Form />);
+      const { getAllByRole } = render(<Form />);
 
-      const radioButtons = screen.getAllByRole('radio');
+      const radioButtons = getAllByRole('radio');
       expect(radioButtons).toHaveLength(2);
     });
 
@@ -33,9 +33,9 @@ describe('Form', () => {
       ${'eito'}    | ${'eito'}
       ${'mei'}     | ${'mei'}
     `('radioボタンのvalue属性が正しく設定されている', ({ checkboxName, expected }) => {
-      render(<Form />);
+      const { getByRole } = render(<Form />);
 
-      const radioButton = screen.getByRole('radio', { name: checkboxName });
+      const radioButton = getByRole('radio', { name: checkboxName });
       expect(radioButton).toHaveAttribute('value', expected);
     });
 
@@ -46,8 +46,8 @@ describe('Form', () => {
     `(
       'radioボタンのチェックを入れると、チェックされたradioボタンの属性がcheckedになっている',
       async ({ checkboxName }) => {
-        render(<Form />);
-        const radioButton = screen.getByRole('radio', { name: checkboxName });
+        const { getByRole } = render(<Form />);
+        const radioButton = getByRole('radio', { name: checkboxName });
 
         await user.click(radioButton);
         expect(radioButton).toBeChecked();
@@ -57,8 +57,8 @@ describe('Form', () => {
 
   describe('checkbox', () => {
     test('checkboxが5つレンダリングされる', () => {
-      render(<Form />);
-      const checkboxes = screen.getAllByRole('checkbox');
+      const { getAllByRole } = render(<Form />);
+      const checkboxes = getAllByRole('checkbox');
       expect(checkboxes).toHaveLength(mockPricesListRaw.data.length);
     });
 
@@ -70,8 +70,8 @@ describe('Form', () => {
       ${'洗濯物片付け'} | ${'landry,20'}
       ${'スペシャル'}   | ${'special,50'}
     `('checkboxのvalue属性が正しく設定されている', ({ checkboxName, expected }) => {
-      render(<Form />);
-      const checkbox = screen.getByRole('checkbox', { name: checkboxName });
+      const { getByRole } = render(<Form />);
+      const checkbox = getByRole('checkbox', { name: checkboxName });
       expect(checkbox).toHaveAttribute('value', expected);
     });
 
@@ -83,8 +83,8 @@ describe('Form', () => {
       ${'洗濯物片付け'}
       ${'スペシャル'}
     `('checkboxのvalue属性が正しく設定されている', async ({ checkboxName }) => {
-      render(<Form />);
-      const checkbox = screen.getByRole('checkbox', { name: checkboxName });
+      const { getByRole } = render(<Form />);
+      const checkbox = getByRole('checkbox', { name: checkboxName });
       await user.click(checkbox);
       expect(checkbox).toBeChecked();
     });
@@ -92,14 +92,14 @@ describe('Form', () => {
 
   describe('textarea', () => {
     test('textareaが1つレンダーされる', () => {
-      render(<Form />);
-      const textarea = screen.getAllByRole('textbox');
+      const { getAllByRole } = render(<Form />);
+      const textarea = getAllByRole('textbox');
       expect(textarea).toHaveLength(1);
     });
 
     test('textareaに入力ができる', async () => {
-      render(<Form />);
-      const textarea = screen.getByRole('textbox');
+      const { getByRole } = render(<Form />);
+      const textarea = getByRole('textbox');
       const typeText = 'テスト';
 
       await user.type(textarea, typeText);
@@ -109,20 +109,20 @@ describe('Form', () => {
 
   describe('button', () => {
     test('buttonが1つ有効な状態でレンダーされる', () => {
-      render(<Form />);
+      const { getByRole } = render(<Form />);
 
-      const button = screen.getByRole('button');
+      const button = getByRole('button');
       expect(button).toBeEnabled();
     });
 
     test('buttonをそのままクリックすると「どちらかを選択してください」と「1つ以上選択してください」のバリデーションエラーがでる', async () => {
-      render(<Form />);
+      const { getByRole, getAllByText } = render(<Form />);
 
-      const button = screen.getByRole('button');
+      const button = getByRole('button');
 
       await user.click(button);
-      expect(screen.getAllByText('どちらかを選択してください')).toHaveLength(1);
-      expect(screen.getAllByText('1つ以上選択してください')).toHaveLength(1);
+      expect(getAllByText('どちらかを選択してください')).toHaveLength(1);
+      expect(getAllByText('1つ以上選択してください')).toHaveLength(1);
     });
   });
 });

--- a/app/(feature)/login/index.test.tsx
+++ b/app/(feature)/login/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useSignIn } from './hooks/useSignIn';
 import { default as Login } from './page';
@@ -16,13 +16,13 @@ describe('Login', () => {
   });
 
   test('Loginのコンポーネントが有効な状態でレンダーされる', () => {
-    render(<Login />);
+    const { getByRole, getByLabelText } = render(<Login />);
 
-    const emailInputComponent = screen.getByRole('textbox', {
+    const emailInputComponent = getByRole('textbox', {
       name: 'メールアドレス',
     });
-    const passwordInputComponent = screen.getByLabelText('パスワード');
-    const loginButtonComponent = screen.getByRole('button');
+    const passwordInputComponent = getByLabelText('パスワード');
+    const loginButtonComponent = getByRole('button');
 
     const loginComponents = [
       {
@@ -45,12 +45,12 @@ describe('Login', () => {
   });
 
   test('emailとpasswordが入力できる', async () => {
-    render(<Login />);
+    const { getByRole, getByLabelText } = render(<Login />);
 
-    const emailInputComponent = screen.getByRole('textbox', {
+    const emailInputComponent = getByRole('textbox', {
       name: 'メールアドレス',
     });
-    const passwordInputComponent = screen.getByLabelText('パスワード');
+    const passwordInputComponent = getByLabelText('パスワード');
 
     const email = 'email@test.com';
     const password = 'password';
@@ -70,13 +70,13 @@ describe('Login', () => {
       }),
     });
 
-    render(<Login />);
+    const { getByRole, getByLabelText } = render(<Login />);
 
-    const emailInputComponent = screen.getByRole('textbox', {
+    const emailInputComponent = getByRole('textbox', {
       name: 'メールアドレス',
     });
-    const passwordInputComponent = screen.getByLabelText('パスワード');
-    const loginButtonComponent = screen.getByRole('button');
+    const passwordInputComponent = getByLabelText('パスワード');
+    const loginButtonComponent = getByRole('button');
 
     expect(loginButtonComponent).toBeEnabled();
 

--- a/app/(feature)/navHeader/indext.test.tsx
+++ b/app/(feature)/navHeader/indext.test.tsx
@@ -1,7 +1,7 @@
 import * as Supabase from '@/app/libs/supabase';
 import * as Zustand from '@/app/store';
 import { AuthError } from '@supabase/supabase-js';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NavHeader } from '.';
 
@@ -38,8 +38,8 @@ describe('NavHeader', () => {
         }) || {},
     );
     signOut = jest.spyOn(Supabase.supabase.auth, 'signOut');
-    render(<NavHeader />);
-    expect(screen.getByText('Record of help')).toBeInTheDocument();
+    const { getByText } = render(<NavHeader />);
+    expect(getByText('Record of help')).toBeInTheDocument();
     expect(useStore).toHaveBeenCalled();
   });
 
@@ -47,8 +47,8 @@ describe('NavHeader', () => {
     useStore = jest.spyOn(Zustand, 'useStore').mockImplementation((state) => state(data));
     signOut = jest.spyOn(Supabase.supabase.auth, 'signOut').mockResolvedValueOnce({ error: null });
 
-    render(<NavHeader />);
-    const logout = screen.getByRole('link', { name: mockedLoginUser });
+    const { getByRole } = render(<NavHeader />);
+    const logout = getByRole('link', { name: mockedLoginUser });
     await user.click(logout);
 
     expect(useStore).toHaveBeenCalled();
@@ -68,8 +68,8 @@ describe('NavHeader', () => {
       } as unknown as AuthError,
     };
     signOut = jest.spyOn(Supabase.supabase.auth, 'signOut').mockRejectedValueOnce({ ...error });
-    render(<NavHeader />);
-    const logout = screen.getByRole('link', { name: mockedLoginUser });
+    const { getByRole } = render(<NavHeader />);
+    const logout = getByRole('link', { name: mockedLoginUser });
     await user.click(logout);
 
     expect(useStore).toHaveBeenCalled();

--- a/app/components/Button/index.test.tsx
+++ b/app/components/Button/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Button, Props } from '.';
 
@@ -17,9 +17,9 @@ describe('Button', () => {
   const user = userEvent.setup();
 
   test('Buttonコンポーネントがレンダリングされる', () => {
-    render(<Button {...mockValues} />);
+    const { getByRole } = render(<Button {...mockValues} />);
 
-    const buttonComponent = screen.getByRole('button');
+    const buttonComponent = getByRole('button');
     expect(buttonComponent).toHaveTextContent(mockValues.label);
   });
 
@@ -29,9 +29,9 @@ describe('Button', () => {
       intent: 'disabled',
     };
 
-    render(<Button {...mockValuesWithDisabledButton} />);
+    const { getByRole } = render(<Button {...mockValuesWithDisabledButton} />);
 
-    const buttonComponent = screen.getByRole('button');
+    const buttonComponent = getByRole('button');
     expect(buttonComponent).toBeDisabled();
   });
 
@@ -41,16 +41,16 @@ describe('Button', () => {
       intent: 'primary',
     };
 
-    render(<Button {...mockValuesWithAttrSubmit} />);
+    const { getByRole } = render(<Button {...mockValuesWithAttrSubmit} />);
 
-    const buttonComponent = screen.getByRole('button');
+    const buttonComponent = getByRole('button');
     expect(buttonComponent).toHaveAttribute('type', mockValues.type);
   });
 
   test('ButtonをクリックするとonClickが呼ばれる', async () => {
-    render(<Button {...mockValues} />);
+    const { getByRole } = render(<Button {...mockValues} />);
 
-    const buttonComponent = screen.getByRole('button');
+    const buttonComponent = getByRole('button');
     await user.click(buttonComponent);
 
     expect(mockValues.onClick).toHaveBeenCalled();
@@ -61,9 +61,9 @@ describe('Button', () => {
       ...mockValues,
       intent: 'disabled',
     };
-    render(<Button {...mockValuesWithAttrSubmit} />);
+    const { getByRole } = render(<Button {...mockValuesWithAttrSubmit} />);
 
-    const buttonComponent = screen.getByRole('button');
+    const buttonComponent = getByRole('button');
     await user.click(buttonComponent);
 
     expect(mockValues.onClick).not.toHaveBeenCalled();

--- a/app/components/Checkbox/index.test.tsx
+++ b/app/components/Checkbox/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Checkbox, Props } from '.';
 
@@ -7,22 +7,21 @@ describe('Checkbox', () => {
     label: 'Checkbox Label',
     id: 'checkbox1',
     value: 'checkboxValue',
-    ref: null,
   };
 
   test('Checkboxがレンダーされる', () => {
-    render(<Checkbox {...mockValues} />);
+    const { getByLabelText, getByRole } = render(<Checkbox {...mockValues} />);
 
-    const labelOfCheckboxComponent = screen.getByLabelText(mockValues.label);
+    const labelOfCheckboxComponent = getByLabelText(mockValues.label);
     expect(labelOfCheckboxComponent).toBeInTheDocument();
 
-    const inputOfCheckboxComponent = screen.getByRole('checkbox');
+    const inputOfCheckboxComponent = getByRole('checkbox');
     expect(inputOfCheckboxComponent).toHaveAttribute('type', 'checkbox');
   });
 
   test('Checkboxがチェックできる', async () => {
-    render(<Checkbox {...mockValues} />);
-    const checkboxComponent = screen.getByRole('checkbox', {
+    const { getByRole } = render(<Checkbox {...mockValues} />);
+    const checkboxComponent = getByRole('checkbox', {
       name: mockValues.label,
     });
 

--- a/app/components/Header/index.test.tsx
+++ b/app/components/Header/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Header, headerText, NavAdminType } from '.';
 
@@ -21,8 +21,8 @@ describe('Header', () => {
   });
 
   test('Headerのタイトルがレンダーされる', () => {
-    render(<Header {...mockData} />);
-    const headerComponent = screen.getByText(headerText);
+    const { getByText } = render(<Header {...mockData} />);
+    const headerComponent = getByText(headerText);
     expect(headerComponent).toBeInTheDocument();
   });
 
@@ -31,16 +31,16 @@ describe('Header', () => {
     ${'Form'}      | ${'./form'}      | ${(<a href="./form">Form</a>)}
     ${'Dashboard'} | ${'./dashboard'} | ${(<a href="./dashboard">Dashboard</a>)}
   `('HeaderのnavとなるLinkがそれぞれ対応するhref属性をもつ', ({ linkName, href }) => {
-    render(<Header {...mockData} />);
+    const { getByRole } = render(<Header {...mockData} />);
 
-    const link = screen.getByRole('link', { name: linkName });
+    const link = getByRole('link', { name: linkName });
     expect(link).toHaveAttribute('href', href);
   });
 
   test('Logoutをクリックすると、propsで渡したonClick関数が1回実行される', async () => {
-    render(<Header {...mockData} />);
+    const { getByText } = render(<Header {...mockData} />);
 
-    const logout = screen.getByText(mockLoginUser);
+    const logout = getByText(mockLoginUser);
     const user = userEvent.setup();
     await user.click(logout);
     expect(mockData.onClick).toHaveBeenCalledTimes(1);

--- a/app/components/Input/index.test.tsx
+++ b/app/components/Input/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Input, Props } from '.';
 
@@ -17,8 +17,8 @@ describe('Input', () => {
   });
 
   test('inputがレンダーされる', () => {
-    render(<Input {...mockValues} />);
-    const inputComponent = screen.getByRole('textbox', {
+    const { getByRole } = render(<Input {...mockValues} />);
+    const inputComponent = getByRole('textbox', {
       name: mockValues.label,
     });
     expect(inputComponent).toHaveAttribute('type', mockValues.type);
@@ -26,9 +26,9 @@ describe('Input', () => {
   });
 
   test('inputに「ほげほげ」と入力ができる', async () => {
-    render(<Input {...mockValues} />);
+    const { getByRole } = render(<Input {...mockValues} />);
 
-    const inputComponent = screen.getByRole('textbox', {
+    const inputComponent = getByRole('textbox', {
       name: mockValues.label,
     });
 
@@ -46,8 +46,8 @@ describe('Input', () => {
       disabled: true,
     };
 
-    render(<Input {...mockValuesWithDisabledButton} />);
-    const inputComponent = screen.getByRole('textbox', {
+    const { getByRole } = render(<Input {...mockValuesWithDisabledButton} />);
+    const inputComponent = getByRole('textbox', {
       name: mockValuesWithDisabledButton.label,
     });
 
@@ -60,8 +60,8 @@ describe('Input', () => {
   });
 
   test('inputをクリックするとonClickが呼ばれる', async () => {
-    render(<Input {...mockValues} />);
-    const inputComponent = screen.getByRole('textbox', {
+    const { getByRole } = render(<Input {...mockValues} />);
+    const inputComponent = getByRole('textbox', {
       name: mockValues.label,
     });
 
@@ -75,8 +75,8 @@ describe('Input', () => {
       disabled: true,
     };
 
-    render(<Input {...mockValuesWithDisabledButton} />);
-    const inputComponent = screen.getByRole('textbox', {
+    const { getByRole } = render(<Input {...mockValuesWithDisabledButton} />);
+    const inputComponent = getByRole('textbox', {
       name: mockValues.label,
     });
 

--- a/app/components/Radio/index.test.tsx
+++ b/app/components/Radio/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Props, Radio } from '.';
 
@@ -10,18 +10,18 @@ describe('Radio', () => {
   };
 
   test('Radioボタンがレンダーされる', () => {
-    render(<Radio {...mockValues} />);
+    const { getByLabelText, getByRole } = render(<Radio {...mockValues} />);
 
-    const labelOfRadio = screen.getByLabelText(mockValues.label);
+    const labelOfRadio = getByLabelText(mockValues.label);
     expect(labelOfRadio).toBeInTheDocument();
 
-    const inputOfRadioComponent = screen.getByRole('radio');
+    const inputOfRadioComponent = getByRole('radio');
     expect(inputOfRadioComponent).toHaveAttribute('type', 'radio');
   });
 
   test('Radioボタンがクリックできる', async () => {
-    render(<Radio {...mockValues} />);
-    const radioComponent = screen.getByRole('radio', {
+    const { getByRole } = render(<Radio {...mockValues} />);
+    const radioComponent = getByRole('radio', {
       name: mockValues.label,
     });
 

--- a/app/components/SelectBox/index.test.tsx
+++ b/app/components/SelectBox/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Props, SelectBox } from '.';
 
@@ -20,14 +20,14 @@ describe('SelectBox', () => {
   });
 
   test('SelectBoxのそれぞれの要素をクリックすると、対応する値になっている', async () => {
-    render(<SelectBox {...mockValues} />);
+    const { getByRole, getByText } = render(<SelectBox {...mockValues} />);
 
-    const select = screen.getByRole('combobox');
+    const select = getByRole('combobox');
     const user = userEvent.setup();
     await user.click(select);
 
     mockOptions.forEach(async (option) => {
-      await user.click(screen.getByText(option.label));
+      await user.click(getByText(option.label));
       expect(select).toHaveAttribute('value', option.value);
     });
   });

--- a/app/components/Table/index.test.tsx
+++ b/app/components/Table/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Props, Table } from '.';
 
 const mockThData = {
@@ -39,25 +39,25 @@ const mockNonTdData: Props | null = [{}];
 
 describe('Table', () => {
   test('2つのデータが表示される', () => {
-    render(<Table thData={mockThData} tdData={mockTdData} />);
+    const { getByText } = render(<Table thData={mockThData} tdData={mockTdData} />);
 
-    expect(screen.getByText('mockPerson1')).toBeInTheDocument();
-    expect(screen.getByText('mockPerson2')).toBeInTheDocument();
+    expect(getByText('mockPerson1')).toBeInTheDocument();
+    expect(getByText('mockPerson2')).toBeInTheDocument();
   });
 
   test('thtとtdの要素数か異なるデータを渡すと「要素の数が異なるため表示できません」が表示される', () => {
-    render(<Table thData={mockThData} tdData={mockNonTdData} />);
+    const { queryByText, getByText } = render(<Table thData={mockThData} tdData={mockNonTdData} />);
 
-    expect(screen.queryByText('mockPerson1')).not.toBeInTheDocument();
-    expect(screen.queryByText('mockPerson2')).not.toBeInTheDocument();
-    expect(screen.getByText('要素の数が異なるため表示できません')).toBeInTheDocument();
+    expect(queryByText('mockPerson1')).not.toBeInTheDocument();
+    expect(queryByText('mockPerson2')).not.toBeInTheDocument();
+    expect(getByText('要素の数が異なるため表示できません')).toBeInTheDocument();
   });
 
   test('tdにnullが渡されると「データがありません」と表示される', () => {
-    render(<Table thData={mockThData} tdData={null} />);
+    const { queryByText, getByText } = render(<Table thData={mockThData} tdData={null} />);
 
-    expect(screen.queryByText('mockPerson1')).not.toBeInTheDocument();
-    expect(screen.queryByText('mockPerson2')).not.toBeInTheDocument();
-    expect(screen.getByText('データがありません')).toBeInTheDocument();
+    expect(queryByText('mockPerson1')).not.toBeInTheDocument();
+    expect(queryByText('mockPerson2')).not.toBeInTheDocument();
+    expect(getByText('データがありません')).toBeInTheDocument();
   });
 });

--- a/app/components/Textarea/index.test.tsx
+++ b/app/components/Textarea/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Props, Textarea } from '.';
 
@@ -10,16 +10,16 @@ describe('Textarea', () => {
   };
 
   test('textareaがレンダーされる', () => {
-    render(<Textarea {...mockValues} />);
-    const labelOfTextareaComponent = screen.getByLabelText(mockValues.label);
+    const { getByLabelText, queryByPlaceholderText } = render(<Textarea {...mockValues} />);
+    const labelOfTextareaComponent = getByLabelText(mockValues.label);
     expect(labelOfTextareaComponent).toBeInTheDocument();
-    const textareaComponent = screen.queryByPlaceholderText(mockValues.placeholder);
+    const textareaComponent = queryByPlaceholderText(mockValues.placeholder);
     expect(textareaComponent).toHaveAttribute('placeholder', mockValues.placeholder);
   });
 
   test('textareaに入力ができる', async () => {
-    render(<Textarea {...mockValues} />);
-    const textareaComponent = screen.getByRole('textbox', {
+    const { getByRole } = render(<Textarea {...mockValues} />);
+    const textareaComponent = getByRole('textbox', {
       name: mockValues.label,
     });
 


### PR DESCRIPTION
- 本筋でないが、ヘルプリストの`fetcher`の`try/catch`が不要な感じだったため削除