### PR TITLE
fact: ダッシュボードのMockデータを外部から取り込むように修正

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -5,6 +5,7 @@
   "words": [
     "nextjs",
     "eito",
+    "tohhiro",
     "hookform",
     "tailwindcss",
     "linebreak",

--- a/app/(feature)/dashboard/components/DashboardTable/index.stories.tsx
+++ b/app/(feature)/dashboard/components/DashboardTable/index.stories.tsx
@@ -1,5 +1,7 @@
+import { mockRawsData } from '@/mocks/rawsData';
+import { mockThData } from '@/mocks/tableHeader';
 import { Meta, StoryObj } from '@storybook/react';
-import { DashboardTable, Props } from '.';
+import { DashboardTable } from '.';
 
 export default {
   title: 'app/feature/dashboard/DashboardTable',
@@ -13,43 +15,6 @@ export default {
 
 type Story = StoryObj<typeof DashboardTable>;
 
-const mockThData = {
-  person: '氏名',
-  dish: '皿洗い',
-  curtain: 'カーテン開閉',
-  landry: '洗濯物',
-  prepareEat: '食事準備',
-  special: 'スペシャル',
-  comments: 'コメント',
-  created_at: '日付',
-};
-const mockTdData: Props = [
-  {
-    comments: null,
-    created_at: '2024-1-2',
-    curtain: 100,
-    del_flag: false,
-    dish: 10,
-    id: '1',
-    landry: 20,
-    person: 'eito',
-    prepareEat: 20,
-    special: 5,
-  },
-  {
-    comments: null,
-    created_at: '2024-1-2',
-    curtain: 100,
-    del_flag: false,
-    dish: 10,
-    id: '1',
-    landry: 20,
-    person: 'mei',
-    prepareEat: 20,
-    special: 5,
-  },
-];
-
 export const Default: Story = {
-  args: { th: mockThData, td: mockTdData },
+  args: { th: mockThData, td: mockRawsData.data },
 };

--- a/app/(feature)/dashboard/components/DashboardTable/index.test.tsx
+++ b/app/(feature)/dashboard/components/DashboardTable/index.test.tsx
@@ -1,42 +1,7 @@
+import { mockRawsData } from '@/mocks/rawsData';
+import { mockThData } from '@/mocks/tableHeader';
 import { render, screen } from '@testing-library/react';
 import { DashboardTable, Props } from '.';
-
-const mockThData = {
-  comments: 'コメント',
-  created_at: '作成日',
-  curtain: 'カーテン',
-  dish: '皿洗い',
-  landry: '洗濯物',
-  person: '氏名',
-  prepareEat: '食事準備',
-  special: 'スペシャル',
-};
-const mockTdData: Props = [
-  {
-    comments: null,
-    created_at: '2024-1-2',
-    curtain: 100,
-    del_flag: false,
-    dish: 10,
-    id: '1',
-    landry: 20,
-    person: 'eito',
-    prepareEat: 20,
-    special: 5,
-  },
-  {
-    comments: null,
-    created_at: '2024-1-2',
-    curtain: 100,
-    del_flag: false,
-    dish: 10,
-    id: '1',
-    landry: 20,
-    person: 'mei',
-    prepareEat: 20,
-    special: 5,
-  },
-];
 
 const mockTdDataWithDelFlag: Props = [
   {
@@ -51,12 +16,12 @@ const mockTdDataWithDelFlag: Props = [
     prepareEat: 20,
     special: 5,
   },
-  { ...mockTdData[1] },
+  { ...mockRawsData.data[1] },
 ];
 
 describe('DashboardTable', () => {
   test('テーブルに2つの氏名が表示され、データにない氏名は表示されない', () => {
-    render(<DashboardTable th={mockThData} td={mockTdData} />);
+    render(<DashboardTable th={mockThData} td={mockRawsData.data} />);
     expect(screen.getByText('eito')).toBeInTheDocument();
     expect(screen.getByText('mei')).toBeInTheDocument();
     expect(screen.queryByText('taro')).not.toBeInTheDocument();
@@ -74,7 +39,7 @@ describe('DashboardTable', () => {
   });
 
   test('tdに正常なデータが渡されても、thに空のオブジェクトが渡されるとコンポーネントは表示されない', () => {
-    const result = render(<DashboardTable th={{}} td={mockTdData} />);
+    const result = render(<DashboardTable th={{}} td={mockRawsData.data} />);
     expect(result.container).toBeEmptyDOMElement();
   });
 });

--- a/mocks/rawsData.ts
+++ b/mocks/rawsData.ts
@@ -33,7 +33,7 @@ export const mockRawsData = {
       landry: 0,
       special: 0,
       comments: null,
-      person: 'eito',
+      person: 'tohhiro',
       del_flag: null,
     },
   ],

--- a/mocks/tableHeader.ts
+++ b/mocks/tableHeader.ts
@@ -1,0 +1,10 @@
+export const mockThData = {
+  person: '氏名',
+  dish: '皿洗い',
+  curtain: 'カーテン開閉',
+  landry: '洗濯物',
+  prepareEat: '食事準備',
+  special: 'スペシャル',
+  comments: 'コメント',
+  created_at: '日付',
+};


### PR DESCRIPTION
- mockデータの重複を削除
- Storybook、およびUTのmockデータを差し替え