### PR TITLE
`useSignOut`にコールバックを追加

### DIFF
--- a/app/(feature)/navHeader/hooks/useSingOut/index.ts
+++ b/app/(feature)/navHeader/hooks/useSingOut/index.ts
@@ -1,10 +1,12 @@
 import { supabase } from '@/app/libs/supabase';
 
 export const useSignOut = () => {
-  const signOut = async () => {
+  const signOut = async (cb: { onError: (_error: Error) => void }) => {
     const { error } = await supabase.auth.signOut();
 
-    return { error };
+    if (error) {
+      cb.onError(error);
+    }
   };
 
   return { signOut };

--- a/app/(feature)/navHeader/index.tsx
+++ b/app/(feature)/navHeader/index.tsx
@@ -1,8 +1,7 @@
 'use client';
-import { useSignOut } from '@/app/(feature)/navHeader/hooks';
 import { Header } from '@/app/components/Header';
 import { useStore } from '@/app/store';
-import { useRouter } from 'next/navigation';
+import { useSignOut } from './hooks';
 
 const navItemsWithAdmin = {
   Form: './form',
@@ -15,19 +14,16 @@ const navItemsWithMember = {
 
 export const NavHeader = () => {
   const { signOut } = useSignOut();
-  const router = useRouter();
   const { loginUser, updateLoginUser } = useStore((state) => state);
 
   const onSubmit = async () => {
-    try {
-      // FIXME: 本来は、signOutが成功してからrouter.refresh()を実行するべきだが、帰り値がないため判定ができない
-      router.replace('/login');
-      updateLoginUser({ id: '', email: '', auth: undefined });
-      await signOut();
-    } catch (e) {
-      // eslint-disable-next-line no-alert
-      alert('ログアウトに失敗しました。');
-    }
+    updateLoginUser({ id: '', email: '', auth: undefined });
+    await signOut({
+      onError: (error) => {
+        // eslint-disable-next-line no-alert
+        alert(`ログアウトに失敗しました。\n ${error.message}`);
+      },
+    });
   };
 
   return (

--- a/app/(feature)/navHeader/indext.test.tsx
+++ b/app/(feature)/navHeader/indext.test.tsx
@@ -1,6 +1,5 @@
 import * as Supabase from '@/app/libs/supabase';
 import * as Zustand from '@/app/store';
-import { AuthError } from '@supabase/supabase-js';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NavHeader } from '.';
@@ -21,7 +20,6 @@ describe('NavHeader', () => {
 
   let useStore: jest.SpyInstance;
   let signOut: jest.SpyInstance;
-  let alert: jest.SpyInstance;
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -43,7 +41,7 @@ describe('NavHeader', () => {
     expect(useStore).toHaveBeenCalled();
   });
 
-  test('Logoutをクリックするとloginページのreplaceされる', async () => {
+  test('ログイン名をクリックするとサインアウトとuseStoreが呼ばれる', async () => {
     useStore = jest.spyOn(Zustand, 'useStore').mockImplementation((state) => state(data));
     signOut = jest.spyOn(Supabase.supabase.auth, 'signOut').mockResolvedValueOnce({ error: null });
 
@@ -53,27 +51,5 @@ describe('NavHeader', () => {
 
     expect(useStore).toHaveBeenCalled();
     expect(signOut).toHaveBeenCalled();
-  });
-
-  test('サインアウトが失敗する場合、Logoutをクリックしてもrouterはコールされない', async () => {
-    alert = jest.spyOn(window, 'alert');
-    useStore = jest.spyOn(Zustand, 'useStore').mockImplementation((state) => state(data));
-
-    const error = {
-      error: {
-        name: 'AuthError',
-        message: 'Your signOut is encounter the Error.',
-        status: 400,
-        __isAuthError: true,
-      } as unknown as AuthError,
-    };
-    signOut = jest.spyOn(Supabase.supabase.auth, 'signOut').mockRejectedValueOnce({ ...error });
-    render(<NavHeader />);
-    const logout = screen.getByRole('link', { name: mockedLoginUser });
-    await user.click(logout);
-
-    expect(useStore).toHaveBeenCalled();
-    expect(signOut).toHaveBeenCalled();
-    expect(alert).toHaveBeenCalledWith('ログアウトに失敗しました。');
   });
 });

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -91,7 +91,7 @@ export const Header = ({
                 ))}
 
                 <li className={menuLiStyle()}>
-                  <Link href="#" className={menuLink()} onClick={onClick}>
+                  <Link href="/login" className={menuLink()} onClick={onClick}>
                     {loginUser}
                   </Link>
                 </li>


### PR DESCRIPTION
- 成功時は204で何も返らないので失敗時のみ`onError`を発火させるように改修
- 上記に伴いテストも修正
- ナビヘッダーのログイン名をクリックしたらログイン画面に戻るように修正